### PR TITLE
Only validate when calling passes(), fails()

### DIFF
--- a/spec/error-messages.spec.js
+++ b/spec/error-messages.spec.js
@@ -9,6 +9,7 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('email')).toEqual('The email field is required.');
 		});
 
@@ -19,6 +20,7 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('email')).toEqual('The email field is required.');
 		});
 
@@ -29,6 +31,7 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.passes()).toBeTruthy();
 			expect(validator.errors.first('email')).toEqual(false);
 		});
 
@@ -39,11 +42,13 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('email')).toEqual('The email format is invalid.');
 		});
 
 		it('should return null for a key without an error message', function() {
 			validator = new Validator({ name: 'David' }, { name: 'required' });
+			expect(validator.passes()).toBeTruthy();
 			expect(validator.errors.first('name')).toBeFalsy();
 		});
 
@@ -66,6 +71,7 @@ describe('Error messages', function() {
 				tweet: 'max:5'
 			});
 
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('age')).toEqual('The age must be at least 18.'); // min numeric
 			expect(validator.errors.first('description')).toEqual('The description must be at least 5 characters.'); // min string
 			expect(validator.errors.first('info')).toEqual('The info field is required.');
@@ -77,27 +83,32 @@ describe('Error messages', function() {
 
 		it('should return a customized alpha error message', function() {
 			validator = new Validator({ name: '12' }, { name: 'alpha' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('name')).toEqual('The name field must contain only alphabetic characters.');
 		});
 
 		it('should fail with non alpha dash characters', function() {
 			validator = new Validator({ name: 'David *' }, { name: 'alpha_dash' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('name')).toEqual('The name field may only contain alpha-numeric characters, as well as dashes and underscores.');
 		});
 
 		it('should fail without a matching confirmation field for the field under validation', function() {
 			var validator = new Validator({ password: 'abc' }, { password: 'confirmed' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('password')).toEqual('The password confirmation does not match.');
 		});
 
 		it('should fail when the 2 attributes are the same', function() {
 			var validator = new Validator({ field1: 'abc', field2: 'abc' }, { field2: 'different:field1' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('field2')).toEqual('The field2 and field1 must be different.');
 		});
 
 		it('should fail with a url only containing http://', function() {
 			var link = 'http://';
 			var validator = new Validator({ link: link }, { link: 'url' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('link')).toEqual('The link format is invalid.');
 		});
 
@@ -107,6 +118,7 @@ describe('Error messages', function() {
 			});
 
 			var validator = new Validator({ phone: '4213-454-9988' }, { phone: 'telephone' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('phone')).toEqual('The phone attribute has errors.');
 		});
 
@@ -116,6 +128,7 @@ describe('Error messages', function() {
 			}, 'The :attribute phone number is not in the format XXX-XXX-XXXX.');
 
 			var validator = new Validator({ cell: '4213-454-9988' }, { cell: 'telephone' });
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.first('cell')).toEqual('The cell phone number is not in the format XXX-XXX-XXXX.');
 		});
 	});
@@ -128,6 +141,7 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.fails()).toBeTruthy();
 			expect(validator.errors.get('email') instanceof Array).toBeTruthy();
 			expect(validator.errors.get('email').length).toEqual(1);
 		});
@@ -139,6 +153,7 @@ describe('Error messages', function() {
 				email: 'required|email'
 			});
 
+			expect(validator.passes()).toBeTruthy();
 			expect(validator.errors.get('email') instanceof Array).toBeTruthy();
 			expect(validator.errors.get('email').length).toEqual(0);
 		});
@@ -167,6 +182,7 @@ describe('Error messages', function() {
 				email: ['The email field is required.']
 			});
 
+			expect(validation.fails()).toBeTruthy();
 			expect(JSON.stringify(validation.errors.all())).toEqual(expected);
 		});
 	});
@@ -187,6 +203,7 @@ describe('Error messages', function() {
 		});
 
 		it('should return an array of all email error messages', function() {
+			expect(validation.fails()).toBeTruthy();
 			expect(validation.errors.has('name')).toEqual(true);
 			expect(validation.errors.has('age')).toEqual(false);
 			expect(validation.errors.has('fake-property')).toEqual(false);

--- a/src/validator.js
+++ b/src/validator.js
@@ -4,10 +4,8 @@ var Validator = function(input, rules, customMessages) {
 	this.rules = rules;
 	this.messages = new ValidatorMessages(lang, customMessages);
 	this.errors = new ValidatorErrors();
-
 	this.errorCount = 0;
 	this.parsedRules = this._parseRules(this.rules);
-	this.check();
 };
 
 Validator.prototype = {
@@ -140,10 +138,12 @@ Validator.prototype = {
 	},
 
 	passes: function() {
+		this.check();
 		return this.errorCount === 0 ? true : false;
 	},
 
 	fails: function() {
+		this.check();
 		return this.errorCount > 0 ? true : false;
 	}
 


### PR DESCRIPTION
Breaking change, but will go in 2.0. This is in prep for allowing `validator.setCustomAttributes(...)` before validating.
