### PR TITLE
feat(options): add option argument to constructor and option.flat

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ var Validator = require('validatorjs');
 ### Basic Usage
 
 ```js
-var validation = new Validator(data, rules [, customErrorMessages]);
+var validation = new Validator(data, rules, [options]);
 ```
 
 __data__ {Object} - The data you want to validate
 
 __rules__ {Object} - Validation rules
 
-__customErrorMessages__ {Object} - Optional custom error messages to return
+__options__ {Object} - Validator Options<br/>
+__options.flat__ {Boolean} [flat = true] - Should `error.all()` return a flat object<br/>
+__options.customErrorMessages__ {Object} - Optional custom error messages to return
 
 #### Example 1 - Passing validation
 
@@ -314,6 +316,18 @@ returns an array of error messages for an attribute, or an empty array if there 
 #### .all()
 
 returns an object containing all error messages for all failing attributes
+
+Depending on `options.flat` value, method returns a flattened /un-flattened object
+
+```javascript
+const validation = new Validator(data, rules);
+const errors = validation.errors.all();
+// > {'foo.bar': 1}
+
+const validation = new Validator(data, rules, {flat: false});
+const errors = validation.errors.all();
+// > {foo: {bar: 1}}
+```
 
 #### .has(attribute)
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "browserify": "^10.2.4",
     "chai": "~3.0.0",
+    "flat": "^2.0.1",
     "grunt": "0.4.5",
     "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",
@@ -52,7 +53,8 @@
     "karma-growl-notifications-reporter": "0.0.2",
     "karma-mocha": "~0.1.10",
     "karma-phantomjs-launcher": "~0.1.4",
-    "mocha": "~2.2.5"
+    "mocha": "~2.2.5",
+    "object-assign": "^4.1.0"
   },
   "scripts": {
     "test-node": "node node_modules/mocha/bin/mocha spec",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,13 @@
     "laravel",
     "laravel-validator-for-js"
   ],
+  "dependencies": {
+    "flat": "^2.0.1",
+    "object-assign": "^4.1.0"
+  },
   "devDependencies": {
     "browserify": "^10.2.4",
     "chai": "~3.0.0",
-    "flat": "^2.0.1",
     "grunt": "0.4.5",
     "grunt-browserify": "^3.8.0",
     "grunt-cli": "^0.1.13",
@@ -53,8 +56,7 @@
     "karma-growl-notifications-reporter": "0.0.2",
     "karma-mocha": "~0.1.10",
     "karma-phantomjs-launcher": "~0.1.4",
-    "mocha": "~2.2.5",
-    "object-assign": "^4.1.0"
+    "mocha": "~2.2.5"
   },
   "scripts": {
     "test-node": "node node_modules/mocha/bin/mocha spec",

--- a/spec/custom-messages.js
+++ b/spec/custom-messages.js
@@ -13,7 +13,9 @@ describe('Validator custom messages', function() {
     }, {
       name: 'required'
     }, {
-      required: 'Name is missing.'
+      customMessages: {
+        required: 'Name is missing.'
+      }
     });
     expect(validator.fails()).to.be.true;
     expect(validator.errors.get('name').length).to.equal(1);
@@ -26,8 +28,10 @@ describe('Validator custom messages', function() {
     }, {
       name: 'min:4'
     }, {
-      min: {
-        string: ':attribute is not long enough. Should be :min.'
+      customMessages: {
+        min: {
+          string: ':attribute is not long enough. Should be :min.'
+        }
       }
     });
     expect(validator.fails()).to.be.true;
@@ -41,7 +45,9 @@ describe('Validator custom messages', function() {
     }, {
       name: 'required'
     }, {
-      required: ':attribute is required. :attribute can\'t be empty.'
+      customMessages: {
+        required: ':attribute is required. :attribute can\'t be empty.'
+      }
     });
     expect(validator.fails()).to.be.true;
     expect(validator.errors.get('name').length).to.equal(1);
@@ -54,8 +60,10 @@ describe('Validator custom messages', function() {
     }, {
       name: 'min:4'
     }, {
-      min: {
-        string: ':attribute is not long enough. Should be :min.'
+      customMessages: {
+        min: {
+          string: ':attribute is not long enough. Should be :min.'
+        }
       }
     });
     expect(validator.fails()).to.be.true;
@@ -69,8 +77,10 @@ describe('Validator custom messages', function() {
     }, {
       name: 'min:4'
     }, {
-      min: {
-        string: ':attribute is not long enough. :attribute should be :min. Because needed string with :min symbols or more.'
+      customMessages: {
+        min: {
+          string: ':attribute is not long enough. :attribute should be :min. Because needed string with :min symbols or more.'
+        }
       }
     });
     expect(validator.fails()).to.be.true;
@@ -86,7 +96,9 @@ describe('Validator custom messages', function() {
       name: 'required',
       email: 'required'
     }, {
-      'required.name': 'Name is missing.'
+      customMessages: {
+        'required.name': 'Name is missing.'
+      }
     });
     expect(validator.fails()).to.be.true;
     expect(validator.errors.get('name').length).to.equal(1);
@@ -105,7 +117,9 @@ describe('Validator custom messages', function() {
     }, {
       phone: 'telephone'
     }, {
-      telephone: 'Wrong number.'
+      customMessages: {
+        telephone: 'Wrong number.'
+      }
     });
     expect(validator.fails()).to.be.true;
     expect(validator.errors.get('phone').length).to.equal(1);
@@ -124,7 +138,9 @@ describe('Validator custom messages', function() {
       phone: 'telephone',
       fax: 'telephone'
     }, {
-      'telephone.fax': 'Why are you even using a fax?'
+      customMessages: {
+        'telephone.fax': 'Why are you even using a fax?'
+      }
     });
     expect(validator.fails()).to.be.true;
     expect(validator.errors.get('phone').length).to.equal(1);

--- a/spec/error-messages.js
+++ b/spec/error-messages.js
@@ -237,7 +237,7 @@ describe('Error messages', function() {
       expect(JSON.stringify(validation.errors.all())).to.equal(expected);
     });
 
-    it('should return an flat array of all email error messages', function() {
+    it('should return an unflat array of all email error messages', function() {
       var validation = new Validator({
         hair: {
           color: 'brown',
@@ -260,26 +260,6 @@ describe('Error messages', function() {
       expect(validation.passes()).to.be.false;
       expect(JSON.stringify(validation.errors.all())).to.equal(expected);
     });
-
-    // it('should return a unflat array of all email error messages', function () {
-    //   var validation = new Validator({
-    //     name: 'd',
-    //     email: '',
-    //     age: 28
-    //   }, {
-    //     name: 'required|min:2',
-    //     email: 'required|email',
-    //     age: 'min:18'
-    //   });
-    //
-    //   var expected = JSON.stringify({
-    //     name: ['The name must be at least 2 characters.'],
-    //     email: ['The email field is required.']
-    //   });
-    //
-    //   expect(validation.passes()).to.be.false;
-    //   expect(JSON.stringify(validation.errors.all())).to.equal(expected);
-    // })
   });
 
   describe('ValidatorErrors.prototype.has()', function() {

--- a/spec/error-messages.js
+++ b/spec/error-messages.js
@@ -216,6 +216,70 @@ describe('Error messages', function() {
       expect(validation.passes()).to.be.false;
       expect(JSON.stringify(validation.errors.all())).to.equal(expected);
     });
+
+    it('should return an flat array of all email error messages', function() {
+      var validation = new Validator({
+        hair: {
+          color: 'brown',
+        }
+      }, {
+        hair: {
+          color: 'required',
+          length: 'required',
+        }
+      });
+
+      var expected = JSON.stringify({
+        'hair.length': ['The hair.length field is required.']
+      });
+
+      expect(validation.passes()).to.be.false;
+      expect(JSON.stringify(validation.errors.all())).to.equal(expected);
+    });
+
+    it('should return an flat array of all email error messages', function() {
+      var validation = new Validator({
+        hair: {
+          color: 'brown',
+        }
+      }, {
+        hair: {
+          color: 'required',
+          length: 'required',
+        }
+      }, {
+        flat: false
+      });
+
+      var expected = JSON.stringify({
+        hair: {
+          length: ['The hair.length field is required.']
+        }
+      });
+
+      expect(validation.passes()).to.be.false;
+      expect(JSON.stringify(validation.errors.all())).to.equal(expected);
+    });
+
+    // it('should return a unflat array of all email error messages', function () {
+    //   var validation = new Validator({
+    //     name: 'd',
+    //     email: '',
+    //     age: 28
+    //   }, {
+    //     name: 'required|min:2',
+    //     email: 'required|email',
+    //     age: 'min:18'
+    //   });
+    //
+    //   var expected = JSON.stringify({
+    //     name: ['The name must be at least 2 characters.'],
+    //     email: ['The email field is required.']
+    //   });
+    //
+    //   expect(validation.passes()).to.be.false;
+    //   expect(JSON.stringify(validation.errors.all())).to.equal(expected);
+    // })
   });
 
   describe('ValidatorErrors.prototype.has()', function() {

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,5 +1,19 @@
-var Errors = function() {
+var flat = require('flat');
+var objectAssign = require('object-assign');
+
+var DEFAULT_OPTIONS = {
+  /**
+   * Whether to flatten the error message object on `all()` call
+   * @type {Boolean}
+   */
+  flat: true
+};
+
+var Errors = function(options) {
   this.errors = {};
+
+  options = options || {}
+  this.options = objectAssign({}, DEFAULT_OPTIONS, options);
 };
 
 Errors.prototype = {
@@ -56,7 +70,11 @@ Errors.prototype = {
    * @return {Object} Failed attribute names for keys and an array of messages for values
    */
   all: function() {
-    return this.errors;
+    if (this.options.flat) {
+      return this.errors;
+    }
+
+    return flat.unflatten(this.errors);
   },
 
   /**

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,7 +12,7 @@ var DEFAULT_OPTIONS = {
 var Errors = function(options) {
   this.errors = {};
 
-  options = options || {}
+  options = options || {};
   this.options = objectAssign({}, DEFAULT_OPTIONS, options);
 };
 


### PR DESCRIPTION
- Replace `customMessages` argument from constructor with an option object.
  
  Before:
  `new Validator(data, rules, customMessages)`
  
  After:
  `new Validator(data, rules, {customMessages})`
- Add `options.flat` option for deciding how `validation.errors.all()`
  returns the object and add tests
  
  new Validator(data, rules, {flat: false})
- Update README.md to reflect changes

**⚠️  BREAKING CHANGE: changed constructor arguments**

Closes #97
