### PR TITLE
bug: date objects arent handled

### DIFF
--- a/spec/date-rule.js
+++ b/spec/date-rule.js
@@ -16,7 +16,8 @@ describe('date rule', function() {
       '1995-08-09',
       '1995-08-09T00:00:00+00:00',
       '1995-08-09T00:00:00Z',
-      '1995-08-09T00:00:00.000Z'
+      '1995-08-09T00:00:00.000Z',
+      (new Date())
     ];
 
     asserts.forEach(function (assert) {

--- a/spec/flatten-object.js
+++ b/spec/flatten-object.js
@@ -20,7 +20,8 @@ describe('Validator', function () {
         [{ foo: { bar: 1 } }, { 'foo.bar' : 1 }],
         [{ foo: { bar: [] } }, { 'foo.bar' : [] }],
         [{ foo: { bar: { fizz: "buzz" } } }, { 'foo.bar.fizz' : "buzz" }],
-        [{ foo: { bar: { fizz: ["buzz"] } } }, { 'foo.bar.fizz' : ["buzz"] }]
+        [{ foo: { bar: { fizz: ["buzz"] } } }, { 'foo.bar.fizz' : ["buzz"] }],
+        [{ date: new Date() }, { 'date': new Date() }]
       ];
       var validator = new Validator({}, {});
 


### PR DESCRIPTION
Inputs aren't handling date objects correctly. The issue is in `flattenObject` method https://github.com/skaterdav85/validatorjs/blob/master/src/validator.js#L160

I found that you can add an additional check there `current instanceof Date`, which should fix it. Let me know if you want me to add that.
