### PR TITLE
Add Norwegian Bokmål (nb_NO) localization

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,14 @@ module.exports = function(grunt) {
           require: ['./src/lang/zh_TW:./lang/zh_TW']
         },
         dest: 'dist/lang/zh_TW.js'
-      },      
+      },
+      nbNOLang: {
+          src: [],
+          options: {
+              require: ['./src/lang/nb_NO:./lang/nb_NO']
+          },
+          dest: 'dist/lang/nb_NO.js'
+      },
       dist: {
         files: {
           'dist/validator.js': 'src/validator.js'

--- a/src/lang/nb_NO.js
+++ b/src/lang/nb_NO.js
@@ -1,0 +1,36 @@
+module.exports = {
+  accepted: ':attribute må være akseptert.',
+  alpha: ':attribute feltet kan kun inneholde alfabetiske tegn.',
+  alpha_dash: ':attribute feltet kan kun inneholde alfanumeriske tegn, i tillegg til bindestreker og understreker.',
+  alpha_num: ':attribute feltet må være alfanumerisk.',
+  between: ':attribute feltet må være mellom :min og :max.',
+  confirmed: ':attribute feltet stemmer ikke overens med bekreftelsen.',
+  email: ':attribute formatet er ugyldig.',
+  date: ':attribute er et ugyldig datoformat.',
+  def: ':attribute attributtet har feil.',
+  digits: ':attribute må være på :digits siffer.',
+  different: ':attribute og :different må være forskjellige.',
+  'in': 'Den oppgitte verdien for :attribute er ugyldig.',
+  integer: ':attribute må være et heltall.',
+  min: {
+    numeric: ':attribute må minst være :min.',
+    string: ':attribute må være på minst :min tegn.'
+  },
+  max: {
+    numeric: ':attribute kan ikke være større enn :max.',
+    string: ':attribute kan maks ha :max tegn.'
+  },
+  'not_in': 'Den oppgitte verdien for :attribute er ugyldig.',
+  numeric: ':attribute må være et tall.',
+  required: ':attribute feltet er påkrevd.',
+  required_if: ':attribute er påkrevd når :other er :value.',
+  same: ':attribute og :same må være like.',
+  size: {
+    numeric: ':attribute må ha størrelsen :size.',
+    string: ':attribute må ha :size tegn.'
+  },
+  string: ':attribute må være tekst.',
+  url: ':attribute formatet er ugyldig.',
+  regex: ':attribute formatet er ugyldig.',
+  attributes: {}
+};


### PR DESCRIPTION
Add localization for the bokmål-standard of the Norwegian language - the other standard being Nynorsk (nn_NO).