### PR TITLE
Make same rule message transform to other lang correctly

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -28,7 +28,22 @@ var replacements = {
       other: parameters[0],
       value: parameters[1]
     });
+  },
+
+  /**
+   * Same replacement.
+   *
+   * @param  {string} template
+   * @param  {Rule} rule
+   * @return {string}
+   */
+  same: function (template, rule) {
+    var parameters = rule.getParameters();
+    return this._replacePlaceholders(rule, template, {
+      same: parameters[0],
+    });
   }
+
 };
 
 function formatter(attribute) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -134,7 +134,7 @@ Messages.prototype = {
     var message, attribute;
 
     data.attribute = this._getAttributeName(rule.attribute);
-    data[rule.name] = rule.getParameters().join(',');
+    data[rule.name] = this._getAttributeName(rule.getParameters().join(','));
 
     if (typeof template === 'string' && typeof data === 'object') {
       message = template;


### PR DESCRIPTION
regarding the below issue. I was facing same issue.

- same:attribute rule not respecting label aliases #138

so, I would like to fix it.

There were 2 problems at present so far.

- missing `same` replacement logic with `attributes.js`
- In `messages.js`, rule parameters should be replaced.

please review me.