### PR TITLE
Nested paths support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 sandbox
 /dist/validator.min.js
 notes.md
+package-lock.json

--- a/spec/after-rule.js
+++ b/spec/after-rule.js
@@ -33,6 +33,76 @@ describe('after rule', function() {
     expect(validator.errors.first('date2')).to.equal('The date2 must be after date.');
   });
 
+  it('should fail when the comparing attribute doesnt exist', function() {
+    var validator = new Validator({
+      date2: '1995-08-09',
+    },{
+      date2: 'after:date'
+    });
+
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be after date.');
+  });
+
+  it('should fail if one of the 2 date is an invalid nested path', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1991-12-09',
+    }, {
+      date2: 'after:payload.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be after payload.date.');
+  })
+
+  it('should fail if one of the 2 date is a invalid nested path with wildcards rule', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1991-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'after:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('payloads.0.date2')).to.equal('The payloads.0.date2 must be after payloads.0.date.');
+  });
+
+  it('should pass if one of the 2 dates is a nested path and smaller', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1996-12-09',
+    }, {
+      date2: 'after:payload.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
+  it('should pass if one of the 2 date is a nested path, smaller and rules are wildcards', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1996-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'after:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
   it('should pass when the comparing attribute are smaller', function() {
     var validator = new Validator({
       date: '1995-08-09',

--- a/spec/after-rule.js
+++ b/spec/after-rule.js
@@ -58,7 +58,7 @@ describe('after rule', function() {
     expect(validator.passes()).to.be.false;
     expect(validator.fails()).to.be.true;
     expect(validator.errors.first('date2')).to.equal('The date2 must be after payload.date.');
-  })
+  });
 
   it('should fail if one of the 2 date is a invalid nested path with wildcards rule', function(){
     var validator = new Validator({

--- a/spec/after_or_equal-rule.js
+++ b/spec/after_or_equal-rule.js
@@ -30,7 +30,7 @@ describe('after or equal rule', function() {
 
     expect(validator.fails()).to.be.false;
     expect(validator.passes()).to.be.true;
-  
+
   });
 
   it('should pass when the comparing attribute are smaller', function() {
@@ -43,5 +43,75 @@ describe('after or equal rule', function() {
 
     expect(validator.fails()).to.be.false;
     expect(validator.passes()).to.be.true;
+  });
+
+  it('should fail when the comparing attribute doesnt exist', function() {
+    var validator = new Validator({
+      date2: '1995-08-09',
+    },{
+      date2: 'after_or_equal:date'
+    });
+
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be equal or after date.');
+  });
+
+  it('should fail if one of the 2 dates is an invalid nested path', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1994-08-09',
+    }, {
+      date2: 'after_or_equal:payload.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be equal or after payload.date.');
+  });
+
+  it('should fail if one of the 2 dates is a invalid nested path with wildcards rule', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1994-08-09',
+      }],
+    }, {
+      'payloads.*.date2': 'after_or_equal:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('payloads.0.date2')).to.equal('The payloads.0.date2 must be equal or after payloads.0.date.');
+  });
+
+  it('should pass if one of the 2 dates is a nested path and equal', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1995-08-09',
+    }, {
+      date2: 'after_or_equal:payload.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
+  it('should pass if one of the 2 dates is a nested path, date is smaller and rules are wildcards', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1996-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'after_or_equal:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
   });
 });

--- a/spec/before-rule.js
+++ b/spec/before-rule.js
@@ -33,6 +33,76 @@ describe('before rule', function() {
     expect(validator.errors.first('date2')).to.equal('The date2 must be before date.');
   });
 
+  it('should fail when the comparing attribute doesnt exist', function() {
+    var validator = new Validator({
+      date2: '1995-08-09',
+    },{
+      date2: 'before:date'
+    });
+
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be before date.');
+  });
+
+  it('should fail if one of the 2 date is an invalid nested path', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1996-12-09',
+    }, {
+      date2: 'before:payload.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be before payload.date.');
+  })
+
+  it('should fail if one of the 2 date is a invalid nested path with wildcards rule', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1996-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'before:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('payloads.0.date2')).to.equal('The payloads.0.date2 must be before payloads.0.date.');
+  });
+
+  it('should pass if one of the 2 dates is a nested path and smaller', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1994-12-09',
+    }, {
+      date2: 'before:payload.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
+  it('should pass if one of the 2 date is a nested path, smaller and rules are wildcards', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1994-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'before:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
   it('should pass when the comparing attribute are greather', function() {
     var validator = new Validator({
       date: '1998-08-09',

--- a/spec/before_or_equal-rule.js
+++ b/spec/before_or_equal-rule.js
@@ -43,4 +43,75 @@ describe('before or equal rule', function() {
     expect(validator.fails()).to.be.false;
     expect(validator.passes()).to.be.true;
   });
+
+  it('should fail when the comparing attribute doesnt exist', function() {
+    var validator = new Validator({
+      date2: '1995-08-09',
+    },{
+      date2: 'before_or_equal:date'
+    });
+
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be equal or before date.');
+  });
+
+  it('should fail if one of the 2 date is an invalid nested path', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1996-12-09',
+    }, {
+      date2: 'before_or_equal:payload.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date2')).to.equal('The date2 must be equal or before payload.date.');
+  });
+
+  it('should fail if one of the 2 date is a invalid nested path with wildcards rule', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1996-12-09',
+      }],
+    }, {
+      'payloads.*.date2': 'before_or_equal:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.false;
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('payloads.0.date2')).to.equal('The payloads.0.date2 must be equal or before payloads.0.date.');
+  });
+
+  it('should pass if one of the 2 dates is a nested path and smaller', function() {
+    var validator = new Validator({
+      payload: {
+        name: 'abc123',
+        date: '1995-08-09'
+      },
+      date2: '1994-12-09',
+    }, {
+      date2: 'before_or_equal:payload.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
+  it('should pass if one of the 2 date is a nested path, date2 issmaller and rules are wildcards', function(){
+    var validator = new Validator({
+      payloads: [{
+        name: 'abc123',
+        date: '1995-08-09',
+        date2: '1994-08-09',
+      }],
+    }, {
+      'payloads.*.date2': 'before_or_equal:payloads.*.date'
+    });
+    expect(validator.passes()).to.be.true;
+    expect(validator.fails()).to.be.false;
+  });
+
 });

--- a/src/rules.js
+++ b/src/rules.js
@@ -339,7 +339,7 @@ var rules = {
   },
 
    after_or_equal: function(val, req){
-    var val1 = this.validator.input[req];
+    var val1 = this.validator._objectPath(this.validator.input, req);
     var val2 = val;
 
     if(!isValidDate(val1)){ return false;}
@@ -353,7 +353,7 @@ var rules = {
   },
 
   before: function(val, req){
-    var val1 = this.validator._objectPath(this.validator.input, req);;
+    var val1 = this.validator._objectPath(this.validator.input, req);
     var val2 = val;
 
     if(!isValidDate(val1)){ return false;}
@@ -367,7 +367,7 @@ var rules = {
   },
 
    before_or_equal: function(val, req){
-    var val1 = this.validator.input[req];
+    var val1 = this.validator._objectPath(this.validator.input, req);
     var val2 = val;
 
     if(!isValidDate(val1)){ return false;}

--- a/src/rules.js
+++ b/src/rules.js
@@ -325,7 +325,7 @@ var rules = {
   },
 
   after: function(val, req){
-    var val1 = this.validator.input[req];
+    var val1 = this.validator._objectPath(this.validator.input, req);
     var val2 = val;
 
     if(!isValidDate(val1)){ return false;}
@@ -353,7 +353,7 @@ var rules = {
   },
 
   before: function(val, req){
-    var val1 = this.validator.input[req];
+    var val1 = this.validator._objectPath(this.validator.input, req);;
     var val2 = val;
 
     if(!isValidDate(val1)){ return false;}


### PR DESCRIPTION
Added nested paths support for 'after', 'before', 'after_or_equal' and 'before_or_equal' rules.