### PR TITLE
Get attribute names for replacement fields

### DIFF
--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1,4 +1,4 @@
-/*! validatorjs - v3.13.5 -  - 2017-10-09 */
+/*! validatorjs - v3.13.5 -  - 2017-11-13 */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Validator = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 function AsyncResolvers(onFailedOne, onResolvedAll) {
   this.onResolvedAll = onResolvedAll;
@@ -110,7 +110,7 @@ var replacements = {
   required_if: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      other: parameters[0],
+      other: this._getAttributeName(parameters[0]),
       value: parameters[1]
     });
   },
@@ -125,7 +125,7 @@ var replacements = {
   required_unless: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      other: parameters[0],
+      other: this._getAttributeName(parameters[0]),
       value: parameters[1]
     });
   },
@@ -140,7 +140,7 @@ var replacements = {
   required_with: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: parameters[0]
+      field: this._getAttributeName(parameters[0])
     });
   },
 
@@ -153,8 +153,9 @@ var replacements = {
    */
   required_with_all: function(template, rule) {
     var parameters = rule.getParameters();
+    var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.join(', ')
+      fields: parameters.map(getAttributeName).join(', ')
     });
   },
 
@@ -168,7 +169,7 @@ var replacements = {
   required_without: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: parameters[0]
+      field: this._getAttributeName(parameters[0])
     });
   },
 
@@ -181,8 +182,9 @@ var replacements = {
    */
   required_without_all: function(template, rule) {
     var parameters = rule.getParameters();
+    var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.join(', ')
+      fields: parameters.map(getAttributeName).join(', ')
     });
   },
 

--- a/spec/attribute-names.js
+++ b/spec/attribute-names.js
@@ -19,4 +19,170 @@ describe('custom attribute names', function() {
     expect(validator.fails()).to.be.true;
     expect(validator.errors.first('name')).to.equal('The custom_name field is required.');
   });
+
+  it('should use custom attribute names for replacements in required_if rule', function() {
+    var validator = new Validator({
+      name: '',
+      req: 'is_required'
+    }, {
+      name: 'required_if:req,is_required'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field is is_required.');
+  });
+
+  it('should use custom attribute names for replacements in required_unless rule', function() {
+    var validator = new Validator({
+      name: '',
+      req: 'not_required'
+    }, {
+      name: 'required_unless:req,is_required'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field is not is_required.');
+  });
+
+  it('should use custom attribute names for replacements in required_with rule', function() {
+    var validator = new Validator({
+      name: '',
+      req: true
+    }, {
+      name: 'required_with:req'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field is not empty.');
+  });
+
+  it('should use custom attribute names for replacements in required_with_all rule', function() {
+    var validator = new Validator({
+      name: '',
+      req1: true,
+      req2: true
+    }, {
+      name: 'required_with_all:req1,req2'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req1: 'other_field_1',
+      req2: 'other_field_2'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field_1, other_field_2 are not empty.');
+  });
+
+  it('should use custom attribute names for replacements in required_without rule', function() {
+    var validator = new Validator({
+      name: '',
+    }, {
+      name: 'required_without:req'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field is empty.');
+  });
+
+  it('should use custom attribute names for replacements in required_without_all rule', function() {
+    var validator = new Validator({
+      name: '',
+    }, {
+      name: 'required_without_all:req1,req2'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      req1: 'other_field_1',
+      req2: 'other_field_2'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name field is required when other_field_1, other_field_2 are empty.');
+  });
+
+  it('should use custom attribute names for replacements in after rule', function() {
+    var validator = new Validator({
+      date: new Date('2017-01-01'),
+      other: new Date('2017-01-02')
+    }, {
+      date: 'after:other'
+    });
+    validator.setAttributeNames({
+      date: 'custom_name',
+      other: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date')).to.equal('The custom_name must be after other_field.');
+  });
+
+  it('should use custom attribute names for replacements in before rule', function() {
+    var validator = new Validator({
+      date: new Date('2017-01-03'),
+      other: new Date('2017-01-02')
+    }, {
+      date: 'before:other'
+    });
+    validator.setAttributeNames({
+      date: 'custom_name',
+      other: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date')).to.equal('The custom_name must be before other_field.');
+  });
+
+  it('should use custom attribute names for replacements in after_or_equal rule', function() {
+    var validator = new Validator({
+      date: new Date('2017-01-01'),
+      other: new Date('2017-01-02')
+    }, {
+      date: 'after_or_equal:other'
+    });
+    validator.setAttributeNames({
+      date: 'custom_name',
+      other: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date')).to.equal('The custom_name must be equal or after other_field.');
+  });
+
+  it('should use custom attribute names for replacements in before_or_equal rule', function() {
+    var validator = new Validator({
+      date: new Date('2017-01-03'),
+      other: new Date('2017-01-02')
+    }, {
+      date: 'before_or_equal:other'
+    });
+    validator.setAttributeNames({
+      date: 'custom_name',
+      other: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('date')).to.equal('The custom_name must be equal or before other_field.');
+  });
+
+  it('should use custom attribute names for replacements in same rule', function() {
+    var validator = new Validator({
+      name: 'name',
+      other: 'other'
+    }, {
+      name: 'same:other'
+    });
+    validator.setAttributeNames({
+      name: 'custom_name',
+      other: 'other_field'
+    })
+    expect(validator.fails()).to.be.true;
+    expect(validator.errors.first('name')).to.equal('The custom_name and other_field fields must match.');
+  });
 });

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -158,6 +158,20 @@ var replacements = {
       before_or_equal: this._getAttributeName(parameters[0])
     });
   },
+
+  /**
+   * Same replacement.
+   *
+   * @param  {string} template
+   * @param  {Rule} rule
+   * @return {string}
+   */
+  same: function(template, rule) {
+    var parameters = rule.getParameters();
+    return this._replacePlaceholders(rule, template, {
+      same: this._getAttributeName(parameters[0])
+    });
+  },
 };
 
 function formatter(attribute) {

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -25,7 +25,7 @@ var replacements = {
   required_if: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      other: parameters[0],
+      other: this._getAttributeName(parameters[0]),
       value: parameters[1]
     });
   },
@@ -40,7 +40,7 @@ var replacements = {
   required_unless: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      other: parameters[0],
+      other: this._getAttributeName(parameters[0]),
       value: parameters[1]
     });
   },
@@ -55,7 +55,7 @@ var replacements = {
   required_with: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: parameters[0]
+      field: this._getAttributeName(parameters[0])
     });
   },
 
@@ -68,8 +68,9 @@ var replacements = {
    */
   required_with_all: function(template, rule) {
     var parameters = rule.getParameters();
+    var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.join(', ')
+      fields: parameters.map(getAttributeName).join(', ')
     });
   },
 
@@ -83,7 +84,7 @@ var replacements = {
   required_without: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: parameters[0]
+      field: this._getAttributeName(parameters[0])
     });
   },
 
@@ -96,8 +97,9 @@ var replacements = {
    */
   required_without_all: function(template, rule) {
     var parameters = rule.getParameters();
+    var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.join(', ')
+      fields: parameters.map(getAttributeName).join(', ')
     });
   },
 


### PR DESCRIPTION
Didn't add an issue for this since it's a pretty minor fix.
All it does is calls `this._getAttributeName` for all custom attribute replacements that has parameters referencing other fields.