### PR TITLE
Removed `:value` placeholder

### DIFF
--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -31,6 +31,6 @@ module.exports = {
         string  : ":attributeは:size文字で入力してください。"
     },
     url        : ":attributeは正しいURIを入力してください。",
-    regex      : ":attributeの値 \":value\" はパターンにマッチする必要があります。",
+    regex      : ":attributeの値はパターンにマッチする必要があります。",
     attributes : {}
 };


### PR DESCRIPTION
## What I did

Removed `:value` placeholder from message to `regex` rule in `lang/ja.js`.

## Reason

- `:value` was not replaced in the message to `regex` rule in `lang/ja.js`.
- Checking `en.js`, `:value` was not written.
- After checking `attributes.js`, `:value` is not given to the message to the ` regex` rule.