### PR TITLE
Add hex rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ The given field must be different than the field under validation.
 
 The field under validation must be formatted as an e-mail address.
 
+#### hex
+The field under validation should be a hexadecimal format. Useful in combination with other rules, like `hex|size:6` for hex color code validation.
+
 #### in:foo,bar,...
 
 The field under validation must be included in the given list of values. The field can be an array or string.

--- a/dist/lang/de.js
+++ b/dist/lang/de.js
@@ -16,6 +16,7 @@ module.exports = {
   digits: 'Das :attribute Feld muss :digits Stellen haben.',
   different: 'Die Felder :attribute und :different müssen sich unterscheiden.',
   'in': 'Der gewählte Wert für :attribute ist ungültig.',
+  hex: 'Das :attribute sollte hexadezimal sein',
   integer: 'Das :attribute Feld muss eine ganze Zahl sein.',
   min: {
     numeric: 'Das :attribute Feld muss mindestens :min sein.',

--- a/dist/lang/el.js
+++ b/dist/lang/el.js
@@ -13,6 +13,7 @@ module.exports = {
   digits: 'Το πεδίο :attribute πρέπει να είναι :digits ψηφία.',
   different: 'Το πεδίο :attribute  και :different πρέπει να είναι διαφορετικά.',
   'in': 'Το επιλεγμένο :attribute δεν είναι έγκυρο.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Το πεδίο :attribute πρέπει να είναι ακέραιος.',
   min: {
     numeric: 'Το πεδίο :attribute πρέπει να είναι τουλάχιστον :min.',

--- a/dist/lang/es.js
+++ b/dist/lang/es.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: 'El campo :attribute debe tener :digits dígitos.',
   email: 'El campo :attribute no es un correo válido.',
   'in': 'El campo :attribute es inválido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'El campo :attribute debe ser un número entero.',
   max: {
     numeric: 'El campo :attribute no debe ser mayor a :max.',

--- a/dist/lang/fa.js
+++ b/dist/lang/fa.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: 'فیلد :attribute می بایست شامل :digits رقم باشد',
   different: 'فیلد :attribute می بایست مقداری غیر از :different داشته باشد',
   'in': 'فیلد :attribute انتخاب شده صحیح نمی باشد',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'فیلد :attribute می بایست عددی باشد',
   min: {
     numeric: 'فیلد :attribute می بایست از :min بزرگتر باشد',

--- a/dist/lang/fr.js
+++ b/dist/lang/fr.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'Le champ :attribute doit être composé de :digits chiffres.',
   different: 'Les champs :attribute et :different doivent être différents.',
   'in': 'Le champ :attribute est invalide.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Le champ :attribute doit être un entier.',
   min: {
     numeric: 'Le champ :attribute doit être supérieur à :min.',

--- a/dist/lang/it.js
+++ b/dist/lang/it.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'Il campo :attribute deve essere di :digits cifre.',
   different: 'Il campo :attribute e :different devo essere diversi.',
   'in': 'Il valore del campo :attribute non è valido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Il campo :attribute deve essere un valore intero.',
   min: {
     numeric: 'Il campo :attribute deve essere maggiore o uguale di :min.',

--- a/dist/lang/ja.js
+++ b/dist/lang/ja.js
@@ -12,6 +12,7 @@ module.exports = {
     digits: ':attributeは:digitsの数字のみで入力してください。',
     different: ':attributeと:differentは同じであってはなりません。',
     'in': '選択された:attributeは無効です。',
+    hex: 'The :attribute should have hexadecimal format',
     integer: ':attributeは整数で入力してください。',
     min        : {
         numeric : ":attributeは:min以上で入力してください。",
@@ -32,7 +33,7 @@ module.exports = {
         string  : ":attributeは:size文字で入力してください。"
     },
     url        : ":attributeは正しいURIを入力してください。",
-    regex      : ":attributeの値 \":value\" はパターンにマッチする必要があります。",
+    regex      : ":attributeの値はパターンにマッチする必要があります。",
     attributes : {}
 };
 

--- a/dist/lang/nb_NO.js
+++ b/dist/lang/nb_NO.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: ':attribute må være på :digits siffer.',
   different: ':attribute og :different må være forskjellige.',
   'in': 'Den oppgitte verdien for :attribute er ugyldig.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute må være et heltall.',
   min: {
     numeric: ':attribute må minst være :min.',

--- a/dist/lang/nl.js
+++ b/dist/lang/nl.js
@@ -16,6 +16,7 @@ module.exports = {
   digits: 'Het :attribute veld moet :digits cijfers hebben.',
   different: 'Het :attribute en :different veld moeten verschillend zijn.',
   'in': 'De gekozen waarde voor :attribute is ongeldig.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Het :attribute veld moet een geheel getal zijn.',
   min: {
     numeric: 'Het :attribute veld moet minstens :min zijn.',

--- a/dist/lang/pl.js
+++ b/dist/lang/pl.js
@@ -12,6 +12,7 @@ module.exports = {
     digits: 'Pole :attribute może zawierać tylko cyfry ze zbioru :digits.',
     different: 'Pola :attribute i :different muszą się różnić.',
     'in': 'Pole :attribute musi należeć do zbioru :in.',
+    hex: 'The :attribute should have hexadecimal format',
     integer: 'Pole :attribute musi być liczbą całkowitą.',
     min: {
         numeric: 'Pole :attribute musi być równe conajmniej :min.',

--- a/dist/lang/pt.js
+++ b/dist/lang/pt.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: 'O atributo :attribute precisa ter :digits dígitos.',
   different: 'O :attribute e :different precisam ser diferentes.',
   'in': 'O atributo selecionado :attribute é inválido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'O :attribute precisa ser um inteiro.',
   min: {
     numeric: 'O :attribute precisa ser no mínimo :min.',

--- a/dist/lang/ru.js
+++ b/dist/lang/ru.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'Длина цифрового поля :attribute должна быть :digits.',
   different: 'Поля :attribute и :different должны различаться.',
   'in': 'Выбранное значение для :attribute ошибочно.',
+  hex: 'Полу :attribute должно иметь шестнадцатеричный формат',
   integer: 'Поле :attribute должно быть целым числом.',
   min: {
     numeric: 'Значение поля :attribute должно быть больше или равно :min.',

--- a/dist/lang/tr.js
+++ b/dist/lang/tr.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: ':attribute sadece rakamlardan oluşabilir.',
   different: ':attribute ve :different farklı olmalı.',
   'in': 'Seçilen :attribute geçerli değil.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute tam sayı olmalı.',
   min: {
     numeric: ':attribute en az :min olmalı.',

--- a/dist/lang/ua.js
+++ b/dist/lang/ua.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'Довжина числового поля :attribute повинна бути :digits.',
   different: 'Поля :attribute і :different повинні відрізнятись.',
   'in': 'Обране значення для :attribute помилкове.',
+  hex: 'Значення поля :attribute повинно бути шістнадцяткового формату',
   integer: 'Значення поля :attribute повинно бути цілим числом.',
   min: {
     numeric: 'Значення поля :attribute повинно бути більшим або рівним :min.',

--- a/dist/lang/vi.js
+++ b/dist/lang/vi.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: ':attribute phải là số và có chiều dài bằng :digits.',
   different: 'Giá trị của hai trường :attribute và :different phải khác nhau.',
   'in': 'Giá trị được chọn của :attribute không hợp lệ.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute phải là số nguyên.',
   min: {
     numeric: ':attribute phải lớn hơn hoặc bằng :min.',

--- a/dist/lang/zh.js
+++ b/dist/lang/zh.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: ':attribute必须是:digits位小数.',
   different: ':attribute和:different必须不同.',
   'in': '选择的:attribute无效',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute必须是一个整数.',
   min: {
     numeric: ':attribute不能小于:min.',

--- a/dist/lang/zh_TW.js
+++ b/dist/lang/zh_TW.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: ':attribute必須是:digits位小數。',
   different: ':attribute和:different必須不同。',
   'in': '選擇的:attribute無效',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute必須是一個整數。',
   min: {
     numeric: ':attribute不能小於:min。',

--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1,4 +1,4 @@
-/*! validatorjs - v3.14.2 -  - 2018-01-11 */
+/*! validatorjs - v3.14.2 -  - 2018-02-01 */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Validator = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 function AsyncResolvers(onFailedOne, onResolvedAll) {
   this.onResolvedAll = onResolvedAll;
@@ -445,6 +445,7 @@ module.exports = {
   digits: 'The :attribute must be :digits digits.',
   different: 'The :attribute and :different must be different.',
   'in': 'The selected :attribute is invalid.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'The :attribute must be an integer.',
   min: {
     numeric: 'The :attribute must be at least :min.',
@@ -1010,9 +1011,11 @@ var rules = {
     }
 
     return false;
+  },
+
+  hex: function(val) {
+    return (/^[0-9a-f]+$/i).test(val);
   }
-
-
 };
 
 var missedRuleValidator = function() {

--- a/spec/hex-rule.js
+++ b/spec/hex-rule.js
@@ -1,0 +1,61 @@
+if (typeof require !== 'undefined') {
+  var Validator = require('../src/validator.js');
+  var expect = require('chai').expect;
+} else {
+  var Validator = window.Validator;
+  var expect = window.chai.expect;
+}
+
+describe('hex validation rule', function() {
+  it('should fail with incorrect hexadecimal values', function() {
+    var validator = new Validator({
+      color: '4d4b8z',
+    }, {
+      color: 'hex',
+    });
+
+    expect(validator.fails()).to.be.true;
+    expect(validator.passes()).to.be.false;
+  }); 
+
+  it('should pass for valid hexadecimal values ', function() {
+    var validator = new Validator({
+      mongoId: '54759eb3c090d83494e2d804',
+      symbolStr: '0',
+      symbolNum: 0,
+      str: 'a'
+    }, {
+      color: 'hex',
+      mongoId: 'hex',
+      symbolStr: 'hex',
+      symbolNum: 'hex',
+      str: 'hex'
+    });
+
+    expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
+  });
+
+  it('should pass with an empty value', function() {
+    var validator = new Validator({
+      color: '',
+      mongoId: ''
+    }, {
+      color: 'hex',
+      mongoId: 'hex'
+    });
+
+    expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
+  });
+
+  it('should pass with an undefined value', function() {
+    var validator = new Validator({}, {
+      color: 'hex',
+      mongoId: 'hex'
+    });
+
+    expect(validator.fails()).to.be.false;
+    expect(validator.passes()).to.be.true;
+  });
+});

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -15,6 +15,7 @@ module.exports = {
   digits: 'Das :attribute Feld muss :digits Stellen haben.',
   different: 'Die Felder :attribute und :different müssen sich unterscheiden.',
   'in': 'Der gewählte Wert für :attribute ist ungültig.',
+  hex: 'Das :attribute sollte hexadezimal sein',
   integer: 'Das :attribute Feld muss eine ganze Zahl sein.',
   min: {
     numeric: 'Das :attribute Feld muss mindestens :min sein.',

--- a/src/lang/el.js
+++ b/src/lang/el.js
@@ -12,6 +12,7 @@ module.exports = {
   digits: 'Το πεδίο :attribute πρέπει να είναι :digits ψηφία.',
   different: 'Το πεδίο :attribute  και :different πρέπει να είναι διαφορετικά.',
   'in': 'Το επιλεγμένο :attribute δεν είναι έγκυρο.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Το πεδίο :attribute πρέπει να είναι ακέραιος.',
   min: {
     numeric: 'Το πεδίο :attribute πρέπει να είναι τουλάχιστον :min.',

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -15,6 +15,7 @@ module.exports = {
   digits: 'The :attribute must be :digits digits.',
   different: 'The :attribute and :different must be different.',
   'in': 'The selected :attribute is invalid.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'The :attribute must be an integer.',
   min: {
     numeric: 'The :attribute must be at least :min.',

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'El campo :attribute debe tener :digits dígitos.',
   email: 'El campo :attribute no es un correo válido.',
   'in': 'El campo :attribute es inválido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'El campo :attribute debe ser un número entero.',
   max: {
     numeric: 'El campo :attribute no debe ser mayor a :max.',

--- a/src/lang/fa.js
+++ b/src/lang/fa.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'فیلد :attribute می بایست شامل :digits رقم باشد',
   different: 'فیلد :attribute می بایست مقداری غیر از :different داشته باشد',
   'in': 'فیلد :attribute انتخاب شده صحیح نمی باشد',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'فیلد :attribute می بایست عددی باشد',
   min: {
     numeric: 'فیلد :attribute می بایست از :min بزرگتر باشد',

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -10,6 +10,7 @@ module.exports = {
   digits: 'Le champ :attribute doit être composé de :digits chiffres.',
   different: 'Les champs :attribute et :different doivent être différents.',
   'in': 'Le champ :attribute est invalide.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Le champ :attribute doit être un entier.',
   min: {
     numeric: 'Le champ :attribute doit être supérieur à :min.',

--- a/src/lang/it.js
+++ b/src/lang/it.js
@@ -10,6 +10,7 @@ module.exports = {
   digits: 'Il campo :attribute deve essere di :digits cifre.',
   different: 'Il campo :attribute e :different devo essere diversi.',
   'in': 'Il valore del campo :attribute non è valido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Il campo :attribute deve essere un valore intero.',
   min: {
     numeric: 'Il campo :attribute deve essere maggiore o uguale di :min.',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -11,6 +11,7 @@ module.exports = {
     digits: ':attributeは:digitsの数字のみで入力してください。',
     different: ':attributeと:differentは同じであってはなりません。',
     'in': '選択された:attributeは無効です。',
+    hex: 'The :attribute should have hexadecimal format',
     integer: ':attributeは整数で入力してください。',
     min        : {
         numeric : ":attributeは:min以上で入力してください。",

--- a/src/lang/nb_NO.js
+++ b/src/lang/nb_NO.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: ':attribute må være på :digits siffer.',
   different: ':attribute og :different må være forskjellige.',
   'in': 'Den oppgitte verdien for :attribute er ugyldig.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute må være et heltall.',
   min: {
     numeric: ':attribute må minst være :min.',

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -15,6 +15,7 @@ module.exports = {
   digits: 'Het :attribute veld moet :digits cijfers hebben.',
   different: 'Het :attribute en :different veld moeten verschillend zijn.',
   'in': 'De gekozen waarde voor :attribute is ongeldig.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'Het :attribute veld moet een geheel getal zijn.',
   min: {
     numeric: 'Het :attribute veld moet minstens :min zijn.',

--- a/src/lang/pl.js
+++ b/src/lang/pl.js
@@ -11,6 +11,7 @@ module.exports = {
     digits: 'Pole :attribute może zawierać tylko cyfry ze zbioru :digits.',
     different: 'Pola :attribute i :different muszą się różnić.',
     'in': 'Pole :attribute musi należeć do zbioru :in.',
+    hex: 'The :attribute should have hexadecimal format',
     integer: 'Pole :attribute musi być liczbą całkowitą.',
     min: {
         numeric: 'Pole :attribute musi być równe conajmniej :min.',

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: 'O atributo :attribute precisa ter :digits dígitos.',
   different: 'O :attribute e :different precisam ser diferentes.',
   'in': 'O atributo selecionado :attribute é inválido.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: 'O :attribute precisa ser um inteiro.',
   min: {
     numeric: 'O :attribute precisa ser no mínimo :min.',

--- a/src/lang/ru.js
+++ b/src/lang/ru.js
@@ -10,6 +10,7 @@ module.exports = {
   digits: 'Длина цифрового поля :attribute должна быть :digits.',
   different: 'Поля :attribute и :different должны различаться.',
   'in': 'Выбранное значение для :attribute ошибочно.',
+  hex: 'Полу :attribute должно иметь шестнадцатеричный формат',
   integer: 'Поле :attribute должно быть целым числом.',
   min: {
     numeric: 'Значение поля :attribute должно быть больше или равно :min.',

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: ':attribute sadece rakamlardan oluşabilir.',
   different: ':attribute ve :different farklı olmalı.',
   'in': 'Seçilen :attribute geçerli değil.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute tam sayı olmalı.',
   min: {
     numeric: ':attribute en az :min olmalı.',

--- a/src/lang/ua.js
+++ b/src/lang/ua.js
@@ -10,6 +10,7 @@ module.exports = {
   digits: 'Довжина числового поля :attribute повинна бути :digits.',
   different: 'Поля :attribute і :different повинні відрізнятись.',
   'in': 'Обране значення для :attribute помилкове.',
+  hex: 'Значення поля :attribute повинно бути шістнадцяткового формату',
   integer: 'Значення поля :attribute повинно бути цілим числом.',
   min: {
     numeric: 'Значення поля :attribute повинно бути більшим або рівним :min.',

--- a/src/lang/vi.js
+++ b/src/lang/vi.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: ':attribute phải là số và có chiều dài bằng :digits.',
   different: 'Giá trị của hai trường :attribute và :different phải khác nhau.',
   'in': 'Giá trị được chọn của :attribute không hợp lệ.',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute phải là số nguyên.',
   min: {
     numeric: ':attribute phải lớn hơn hoặc bằng :min.',

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: ':attribute必须是:digits位小数.',
   different: ':attribute和:different必须不同.',
   'in': '选择的:attribute无效',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute必须是一个整数.',
   min: {
     numeric: ':attribute不能小于:min.',

--- a/src/lang/zh_TW.js
+++ b/src/lang/zh_TW.js
@@ -11,6 +11,7 @@ module.exports = {
   digits: ':attribute必須是:digits位小數。',
   different: ':attribute和:different必須不同。',
   'in': '選擇的:attribute無效',
+  hex: 'The :attribute should have hexadecimal format',
   integer: ':attribute必須是一個整數。',
   min: {
     numeric: ':attribute不能小於:min。',

--- a/src/rules.js
+++ b/src/rules.js
@@ -378,9 +378,11 @@ var rules = {
     }
 
     return false;
+  },
+
+  hex: function(val) {
+    return (/^[0-9a-f]+$/i).test(val);
   }
-
-
 };
 
 var missedRuleValidator = function() {


### PR DESCRIPTION
After discussing in issues the need to check for hexadecimal values (like mongoId or color code), I think it will be useful to have a **hex** rule. Like a small building block for more complex rules. 

@skaterdav85 , @mikeerickson Let me know if you find this rule useful, and I will extend PR with additional languages.  And build for a browser.

Thanks a lot.