### PR TITLE
Fix regex rules check of validator. Change val.match(req) to req.test(val)

### DIFF
--- a/dist/validator.js
+++ b/dist/validator.js
@@ -1,4 +1,4 @@
-/*! validatorjs - v3.14.2 -  - 2018-02-01 */
+/*! validatorjs - v3.14.2 -  - 2018-02-21 */
 (function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.Validator = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 function AsyncResolvers(onFailedOne, onResolvedAll) {
   this.onResolvedAll = onResolvedAll;
@@ -946,7 +946,7 @@ var rules = {
     flag = flag ? flag[0] : "";
     req = req.replace(mod, "").slice(1, -1);
     req = new RegExp(req, flag);
-    return !!val.match(req);
+    return !!req.test(val);
   },
 
   date: function(val, format) {

--- a/spec/regex-rule.js
+++ b/spec/regex-rule.js
@@ -147,4 +147,68 @@ describe('regex validation rule for most common regular expressions', function()
 
     expect(validator.fails()).to.be.true;
   });
+
+  it('should pass with the string: 12-500.00A', function() {
+    var validator = new Validator({
+      pattern: '12-500.00A'
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/']
+    });
+    expect(validator.passes()).to.be.true;
+  });
+
+  it('should fail with the string: 12-500.00/A', function() {
+    var validator = new Validator({
+      pattern: '12-500.00/A'
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/']
+    });
+    expect(validator.fails()).to.be.true;
+  });
+
+  it('should pass with the string: 12.500', function() {
+    var validator = new Validator({
+      pattern: '12.500'
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/i']
+    });
+    expect(validator.passes()).to.be.true;
+  });
+
+  it('should fail with the string: 12.500,00', function() {
+    var validator = new Validator({
+      pattern: '12.500,00'
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/i']
+    });
+    expect(validator.fails()).to.be.true;
+  });
+
+  it('should pass with the number: 12.500', function() {
+    var validator = new Validator({
+      pattern: 12.500
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/i']
+    });
+    expect(validator.passes()).to.be.true;
+  });
+
+  it('should fail with the number: -12.500', function() {
+    var validator = new Validator({
+      pattern: -12.500
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\.]+$/i']
+    });
+    expect(validator.fails()).to.be.true;
+  });
+
+  it('should pass with the number: 999', function() {
+    var validator = new Validator({
+      pattern: 999
+    }, {
+      pattern: ['regex:/^[A-Za-z0-9_\\-\\.]+$/i']
+    });
+    expect(validator.passes()).to.be.true;
+  });
+
 });

--- a/src/rules.js
+++ b/src/rules.js
@@ -313,7 +313,7 @@ var rules = {
     flag = flag ? flag[0] : "";
     req = req.replace(mod, "").slice(1, -1);
     req = new RegExp(req, flag);
-    return !!val.match(req);
+    return !!req.test(val);
   },
 
   date: function(val, format) {


### PR DESCRIPTION
**Ex Done:**
```
var val = 999;
var regex = /^[0-9]+$/i;
console.log(regex.test(val)); // Return true
```

**Ex Fail:**
```
var val = 999;
var regex = /^[0-9]+$/i;
console.log(val.match(regex)); // Return FAIL: val.match is not a function
```
A similar change was made in https://github.com/skaterdav85/validatorjs/pull/35

