### PR TITLE
Expand wildcard documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,17 @@ let rules = {
   'users.*.name': 'required',
   'users.*.bio.age': 'min:18'
   'users.*.bio.education.primary': 'string',
-  'users.*.bio.education.secondary': 'string'
+  'users.*.bio.education.secondary': 'string',
+  'users.*.bio.education.primary': 'required_with:users.*.bio.education.secondary'
 };
+```
+
+And provide custom error messages like so:
+
+```js
+let errorMessages = {
+  'required_with.users.*.bio.education.primary': 'Primary education is required when specifying secondary'
+}
 ```
 
 ### Available Rules


### PR DESCRIPTION
I wasn't sure if the wildcard was substituted in all places or how to set it up.
Luckily I found a great example in the wildcard test.

I could also see adding a doubly nested example (`users.*.bio.education.certificates.*.name`?).