### PR TITLE
Update Attribute replacement with fallback

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -56,7 +56,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       field: this._getAttributeName(parameters[0]),
-      values: this._getAttributeName(parameters[0]),
+      values: this._getAttributeName(parameters[0])
     });
   },
 
@@ -72,7 +72,7 @@ var replacements = {
     var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
       fields: parameters.map(getAttributeName).join(', '),
-      values: parameters.map(getAttributeName).join(', '),
+      values: parameters.map(getAttributeName).join(', ')
     });
   },
 
@@ -102,7 +102,7 @@ var replacements = {
     var parameters = rule.getParameters();
     var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.map(getAttributeName).join(', ')
+      fields: parameters.map(getAttributeName).join(', '),
       values: parameters.map(getAttributeName).join(', ')
     });
   },
@@ -118,7 +118,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       after: this._getAttributeName(parameters[0]),
-      date: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0])
     });
   },
 
@@ -133,7 +133,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       before: this._getAttributeName(parameters[0]),
-      date: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0])
     });
   },
 
@@ -148,7 +148,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       after_or_equal: this._getAttributeName(parameters[0]),
-      date: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0])
     });
   },
 
@@ -163,7 +163,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       before_or_equal: this._getAttributeName(parameters[0]),
-      date: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0])
     });
   },
 
@@ -178,7 +178,7 @@ var replacements = {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
       same: this._getAttributeName(parameters[0]),
-      other: this._getAttributeName(parameters[0]),
+      other: this._getAttributeName(parameters[0])
     });
   },
 };

--- a/src/attributes.js
+++ b/src/attributes.js
@@ -55,7 +55,8 @@ var replacements = {
   required_with: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: this._getAttributeName(parameters[0])
+      field: this._getAttributeName(parameters[0]),
+      values: this._getAttributeName(parameters[0]),
     });
   },
 
@@ -70,7 +71,8 @@ var replacements = {
     var parameters = rule.getParameters();
     var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
-      fields: parameters.map(getAttributeName).join(', ')
+      fields: parameters.map(getAttributeName).join(', '),
+      values: parameters.map(getAttributeName).join(', '),
     });
   },
 
@@ -84,7 +86,8 @@ var replacements = {
   required_without: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      field: this._getAttributeName(parameters[0])
+      field: this._getAttributeName(parameters[0]),
+      values: this._getAttributeName(parameters[0])
     });
   },
 
@@ -100,6 +103,7 @@ var replacements = {
     var getAttributeName = this._getAttributeName.bind(this);
     return this._replacePlaceholders(rule, template, {
       fields: parameters.map(getAttributeName).join(', ')
+      values: parameters.map(getAttributeName).join(', ')
     });
   },
 
@@ -113,7 +117,8 @@ var replacements = {
   after: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      after: this._getAttributeName(parameters[0])
+      after: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0]),
     });
   },
 
@@ -127,7 +132,8 @@ var replacements = {
   before: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      before: this._getAttributeName(parameters[0])
+      before: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0]),
     });
   },
 
@@ -141,7 +147,8 @@ var replacements = {
   after_or_equal: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      after_or_equal: this._getAttributeName(parameters[0])
+      after_or_equal: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0]),
     });
   },
 
@@ -155,7 +162,8 @@ var replacements = {
   before_or_equal: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      before_or_equal: this._getAttributeName(parameters[0])
+      before_or_equal: this._getAttributeName(parameters[0]),
+      date: this._getAttributeName(parameters[0]),
     });
   },
 
@@ -169,7 +177,8 @@ var replacements = {
   same: function(template, rule) {
     var parameters = rule.getParameters();
     return this._replacePlaceholders(rule, template, {
-      same: this._getAttributeName(parameters[0])
+      same: this._getAttributeName(parameters[0]),
+      other: this._getAttributeName(parameters[0]),
     });
   },
 };


### PR DESCRIPTION
We have decided to use the exact translations as in the backend to be concise, so the attribute replacement did not work for us.

In https://github.com/laravel/laravel/blob/master/resources/lang/en/validation.php and 
https://github.com/caouecs/Laravel-lang/ the attribute names are named concisely.

However, in this library, the additional attributes are defined a bit differently e.g. ```The :attribute must be before :before.``` where in laravel the message is ```The :attribute must be a date before :date.```

Also, in #294 PR, the translations were introduced without taking into account attribute names for replacement in this library, so this PR solves the problem for new languages.

Ideally, the attribute names should be concise with the original validation library, but it could be that someone added the translations themselves, so to avoid breaking changes, I have added a fallback.