### PR TITLE
Added missing attributes key to all language files

### DIFF
--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -5,6 +5,7 @@ module.exports = {
   alpha: 'حقل الصفة  :attribute يجب أن تحتوي على أحرف فقط',
   alpha_dash: 'حقل الصفة :attribute مسموح بأن يحتوي على حروف و أرقام و شرطة و شرطة منخفضة',
   alpha_num: 'حقل الصفة :attribute يجب أن يحتوي على أحرف و أرقام',
+  attributes: {},
   before: 'الصفة :attribute يجب أن تكون قبل :before.',
   before_or_equal: 'الصفة :attribute يجب أن تكون مساوية أو قبل الصفة :before_or_equal.',
   between: 'حقل الصفة :attribute يجب أن يكون بين :min و :max.',

--- a/src/lang/az.js
+++ b/src/lang/az.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: ':attribute yalnız hərflərdən ibarət ola bilər',
   alpha_dash: ':attribute yalnız hərf, rəqəm və tire simvolundan ibarət ola bilər',
   alpha_num: ':attribute yalnız hərf və rəqəmlərdən ibarət ola bilər',
+  attributes: {},
   array: ':attribute massiv formatında olmalıdır',
   before: ':attribute :date tarixindən əvvəl olmalıdır',
   before_or_equal: ':attribute :date tarixindən əvvəl və ya bərabər olmalıdır',

--- a/src/lang/be.js
+++ b/src/lang/be.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'Поле :attribute можа мець толькі літары.',
   alpha_dash: 'Поле :attribute можа мець толькі літары, лічбы і злучок.',
   alpha_num: 'Поле :attribute можа мець толькі літары і лічбы.',
+  attributes: {},
   array: 'Поле :attribute павінна быць масівам.',
   before: 'У полі :attribute павінна быць дата да :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',

--- a/src/lang/bg.js
+++ b/src/lang/bg.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'Полето :attribute трябва да съдържа само букви.',
   alpha_dash: 'Полето :attribute трябва да съдържа само букви, цифри, долна черта и тире.',
   alpha_num: 'Полето :attribute трябва да съдържа само букви и цифри.',
+  attributes: {},
   array: 'Полето :attribute трябва да бъде масив.',
   before: 'Полето :attribute трябва да бъде дата преди :date.',
   before_or_equal: 'Полето :attribute трябва да бъде дата преди или равна на :date.',

--- a/src/lang/bs.js
+++ b/src/lang/bs.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'Polje :attribute može sadržati samo slova.',
   alpha_dash: 'Polje :attribute može sadržati samo slova, brojeve i povlake.',
   alpha_num: 'Polje :attribute može sadržati samo slova i brojeve.',
+  attributes: {},
   array: 'Polje :attribute mora biti niz.',
   before: 'Polje :attribute mora biti datum prije :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',

--- a/src/lang/cs.js
+++ b/src/lang/cs.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: ':attribute může obsahovat pouze písmena.',
   alpha_dash: ':attribute může obsahovat pouze písmena, číslice, pomlčky a podtržítka. České znaky (á, é, í, ó, ú, ů, ž, š, č, ř, ď, ť, ň) nejsou podporovány.',
   alpha_num: ':attribute může obsahovat pouze písmena a číslice.',
+  attributes: {},
   array: ':attribute musí být pole.',
   before: ':attribute musí být datum před :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',

--- a/src/lang/cy.js
+++ b/src/lang/cy.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: "Dim ond llythrennau'n unig gall :attribute gynnwys.",
   alpha_dash: 'Dim ond llythrennau, rhifau a dash yn unig gall :attribute gynnwys.',
   alpha_num: 'Dim ond llythrennau a rhifau yn unig gall :attribute gynnwys.',
+  attributes: {},
   array: 'Rhaid i :attribute fod yn array.',
   before: 'Rhaid i :attribute fod yn ddyddiad sydd cyn :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',

--- a/src/lang/el.js
+++ b/src/lang/el.js
@@ -4,6 +4,7 @@ module.exports = {
   alpha: 'Το πεδίο :attribute μπορεί να περιέχει μόνο γράμματα.',
   alpha_dash: 'Το πεδίο :attribute μπορεί να περιέχει μόνο γράμματα, αριθμούς, και παύλες.',
   alpha_num: 'Το πεδίο :attribute μπορεί να περιέχει μόνο γράμματα και αριθμούς.',
+  attributes: {},
   between: 'Το πεδίο :attribute πρέπει να είναι μεταξύ :min και :max.',
   confirmed: 'Η επιβεβαίωση του :attribute δεν ταιριάζει.',
   email: 'Το πεδίο :attribute πρέπει να είναι μία έγκυρη διεύθυνση email.',

--- a/src/lang/et.js
+++ b/src/lang/et.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: ':attribute võib sisaldada vaid tähemärke.',
   alpha_dash: ':attribute võib sisaldada vaid tähti, numbreid ja kriipse.',
   alpha_num: ':attribute võib sisaldada vaid tähti ja numbreid.',
+  attributes: {},
   array: ':attribute peab olema massiiv.',
   before: ':attribute peab olema kuupäev enne :date.',
   before_or_equal: ':attribute peab olema kuupäev enne või samastuma :date.',

--- a/src/lang/eu.js
+++ b/src/lang/eu.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: ':attribute hizkiak besterik ezin ditu izan.',
   alpha_dash: ':attribute hizkiak, zenbakiak eta marrak besterik ezin ditu izan.',
   alpha_num: ':attribute hizkiak eta zenbakiak besterik ezin ditu izan.',
+  attributes: {},
   array: ':attribute bilduma izan behar da.',
   before: ':attribute :date aurreko data izan behar da.',
   before_or_equal: ':attribute :date aurreko data edo data berdina izan behar da.',

--- a/src/lang/hr.js
+++ b/src/lang/hr.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'Polje :attribute smije sadržavati samo slova.',
   alpha_dash: 'Polje :attribute smije sadržavati samo slova, brojeve i crtice.',
   alpha_num: 'Polje :attribute smije sadržavati samo slova i brojeve.',
+  attributes: {},
   array: 'Polje :attribute mora biti niz.',
   before: 'Polje :attribute mora biti datum prije :date.',
   before_or_equal: 'Polje :attribute mora biti datum manji ili jednak :date.',

--- a/src/lang/hu.js
+++ b/src/lang/hu.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'A(z) :attribute kizárólag betűket, számokat és kötőjeleket tartalmazhat!',
   alpha_num: 'A(z) :attribute kizárólag betűket és számokat tartalmazhat!',
   array: 'A(z) :attribute egy tömb kell, hogy legyen!',
+  attributes: {},
   before: 'A(z) :attribute :date előtti dátum kell, hogy legyen!',
   before_or_equal: 'A(z) :attribute nem lehet későbbi dátum, mint :date!',
   between: {

--- a/src/lang/ka.js
+++ b/src/lang/ka.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: ':attribute უნდა შეიცავდეს მხოლოდ ასოებს.',
   alpha_dash: ':attribute უნდა შეიცავდეს მხოლოდ ასოებს, რიცხვებს და ტირეებს.',
   alpha_num: ':attribute უნდა შეიცავდეს მხოლოდ ასოებს და რიცხვებს.',
+  attributes: {},
   array: ':attribute უნდა იყოს მასივი.',
   before: ':attribute უნდა იყოს :date-მდე.',
   before_or_equal: ':attribute უნდა იყოს :date-მდე ან მისი ტოლი.',

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute은(는) 문자, 숫자, 대쉬(-)만 포함할 수 있습니다.',
   alpha_num: ':attribute은(는) 문자와 숫자만 포함할 수 있습니다.',
   array: ':attribute은(는) 배열이어야 합니다.',
+  attributes: {},
   before: ':attribute은(는) :date 이전 날짜여야 합니다.',
   before_or_equal: ':attribute은(는) :date 이전 날짜이거나 같은 날짜여야 합니다.',
   between: {

--- a/src/lang/lt.js
+++ b/src/lang/lt.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'Laukas :attribute gali turėti tik raides, skaičius ir brūkšnelius.',
   alpha_num: 'Laukas :attribute gali turėti tik raides ir skaičius.',
   array: 'Laukas :attribute turi būti masyvas.',
+  attributes: {},
   before: 'Laukas :attribute turi būti data prieš :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',
   between: {

--- a/src/lang/lv.js
+++ b/src/lang/lv.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ' :attribute var saturēt tikai burtus, nummurus un atstarpes.',
   alpha_num: ' :attribute var tikai saturēt burtus un nummurus.',
   array: ' :attribute ir jābūt sakārtotam.',
+  attributes: {},
   before: ' :attribute ir jābūt ar datumu pirms :datums.',
   before_or_equal: ' :attribute ir jābūt ar datumu pirms vai vienādu ar :datums.',
   between: {

--- a/src/lang/mk.js
+++ b/src/lang/mk.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'Полето :attribute може да содржи само букви.',
   alpha_dash: 'Полето :attribute може да содржи само букви, цифри, долна црта и тире.',
   alpha_num: 'Полето :attribute може да содржи само букви и цифри.',
+  attributes: {},
   array: 'Полето :attribute мора да биде низа.',
   before: 'Полето :attribute мора да биде датум пред :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',

--- a/src/lang/mn.js
+++ b/src/lang/mn.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':Attribute талбарт латин үсэг, тоо болон зураас оруулах боломжтой.',
   alpha_num: ':Attribute талбарт латин үсэг болон тоо оруулах боломжтой.',
   array: ':Attribute талбар массив байх шаардлагатай.',
+  attributes: {},
   before: ':Attribute талбарт :date-с өмнөх огноо оруулна уу.',
   before_or_equal: ':attribute талбарт :date эсвэл түүнээс өмнөх огноо оруулна уу.',
   between: {

--- a/src/lang/ms.js
+++ b/src/lang/ms.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute boleh mengandungi huruf, nombor, dan sengkang.',
   alpha_num: ':attribute boleh mengandungi huruf dan nombor.',
   array: ':attribute mesti jujukan.',
+  attributes: {},
   before: ':attribute mesti tarikh sebelum :date.',
   before_or_equal: ':attribute mesti tarikh sebelum atau sama dengan :date.',
   between: {

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -6,6 +6,7 @@ module.exports = {
   alpha: 'O campo :attribute deverá conter apenas letras.',
   alpha_dash: 'O campo :attribute deverá conter apenas letras, números e traços.',
   alpha_num: 'O campo :attribute deverá conter apenas letras e números .',
+  attributes: {},
   array: 'O campo :attribute deverá conter uma coleção de elementos.',
   before: 'O campo :attribute deverá conter uma data anterior a :date.',
   before_or_equal: 'O Campo :attribute deverá conter uma data anterior ou igual a :date.',

--- a/src/lang/sl.js
+++ b/src/lang/sl.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute lahko vsebuje samo črke, številke in črtice.',
   alpha_num: ':attribute lahko vsebuje samo črke in številke.',
   array: ':attribute mora biti polje.',
+  attributes: {},
   before: ':attribute mora biti pred datumom :date.',
   before_or_equal: ':attribute mora biti pred ali enak :date.',
   between: {

--- a/src/lang/sq.js
+++ b/src/lang/sq.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute mund të përmbajë vetëm shkronja, numra, dhe viza.',
   alpha_num: ':attribute mund të përmbajë vetëm shkronja dhe numra.',
   array: ':attribute duhet të jetë një bashkësi (array).',
+  attributes: {},
   before: ':attribute duhet të jetë datë para :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',
   between: {

--- a/src/lang/sr.js
+++ b/src/lang/sr.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'Polje :attribute može sadržati samo slova, brojeve i povlake.',
   alpha_num: 'Polje :attribute može sadržati samo slova i brojeve.',
   array: 'Polje :attribute mora sadržati nekih niz stavki.',
+  attributes: {},
   before: 'Polje :attribute mora biti datum pre :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',
   between: {

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute får endast innehålla bokstäver, siffror och bindestreck.',
   alpha_num: ':attribute får endast innehålla bokstäver och siffror.',
   array: ':attribute måste vara en array.',
+  attributes: {},
   before: ':attribute måste vara ett datum innan den :date.',
   before_or_equal: ':attribute måste vara ett datum före eller samma dag som :date.',
   between: {

--- a/src/lang/uk.js
+++ b/src/lang/uk.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'Поле :attribute має містити лише літери, цифри та підкреслення.',
   alpha_num: 'Поле :attribute має містити лише літери та цифри.',
   array: 'Поле :attribute має бути масивом.',
+  attributes: {},
   before: 'Поле :attribute має містити дату не пізніше :date.',
   before_or_equal: 'Поле :attribute має містити дату не пізніше або дорівнюватися :date.',
   between: {


### PR DESCRIPTION
I found a problem with missing "attributes" key in language files, the same as #319  and #299. This PR adds this key to all files where it is missing.

Signed-off-by: Jakub Koudelka <koudelka.j@gmail.com>