### PR TITLE
update asynchronous validation example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 validatorjs
 ===========
 
+This package is forked from skaterdav85/validatorjs, he doesn't seem to maintain it anymore
+
 [![Build Status](https://travis-ci.org/skaterdav85/validatorjs.png?branch=master)](https://travis-ci.org/skaterdav85/validatorjs)
 
 The validatorjs library makes data validation in JavaScript very easy in both the browser and Node.js. This library was inspired by the [Laravel framework's Validator](http://laravel.com/docs/validation).

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Validator.registerAsync('username_available', function(username, attribute, req,
 });
 ```
 
-Then call your validator passing a callback to `fails` or `passes` like so:
+Then call your validator using `checkAsync` passing `fails` and `passes` callbacks like so:
 
 ```js
 let validator = new Validator({
@@ -390,16 +390,17 @@ let validator = new Validator({
 	username: 'required|min:3|username_available'
 });
 
-validator.passes(function() {
+function passes() {
   // Validation passed
-});
+}
 
-validator.fails(function() {
+function fails() {
   validator.errors.first('username');
-});
-```
+}
 
-Note: if you attempt to call `passes` or `fails` without a callback and the validator detects there are asynchronous validation rules, an exception will be thrown.
+validator.checkAsync(passes, fails);
+
+```
 
 ### Error Messages
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "validatorjs",
+  "name": "validatorjs2",
   "description": "Validation library inspired by Laravel's Validator",
   "version": "3.15.0",
   "author": "David <david@thejsguy.com>",
@@ -25,6 +25,7 @@
   },
   "keywords": [
     "validatorjs",
+    "validatorjs2",
     "validator.js",
     "data validation",
     "validator",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
   "main": "./src/validator.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/skaterdav85/validatorjs"
-  },
-  "bugs": {
-    "url": "https://github.com/skaterdav85/validatorjs/issues?labels=bug&milestone=1&page=1&state=open"
+    "url": "https://github.com/kaareloun/validatorjs"
   },
   "keywords": [
     "validatorjs",

--- a/src/validator.js
+++ b/src/validator.js
@@ -206,7 +206,7 @@ Validator.prototype = {
     }
 
     for (var i = 0, l = keys.length; i < l; i++) {
-      if (Object.hasOwnProperty.call(copy, keys[i])) {
+      if (typeof copy === 'object' && copy !== null && Object.hasOwnProperty.call(copy, keys[i])) {
         copy = copy[keys[i]];
       } else {
         return;


### PR DESCRIPTION
Changes the asynchronous validation example. With the current example the validation will be run twice, so if you have for example database queries in an async validation rule the validation will take alot longer than needed. Using checkAsync there will only be a single validation