### PR TITLE
Fix object validation

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -206,7 +206,7 @@ Validator.prototype = {
     }
 
     for (var i = 0, l = keys.length; i < l; i++) {
-      if (Object.hasOwnProperty.call(copy, keys[i])) {
+      if (typeof copy === 'object' && copy !== null && Object.hasOwnProperty.call(copy, keys[i])) {
         copy = copy[keys[i]];
       } else {
         return;


### PR DESCRIPTION
Fixes an exception when validating a child of an object and the actual object is null or undefined.

for example this rule will throw an exception when user object doesn't exist
```
user: {
    name: 'required_with:user',
}
```