### PR TITLE
Bundle size optimized via different date-fns imports

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1,4 +1,5 @@
-var dateTools = require('date-fns');
+var isDateValid = require('date-fns/isValid');
+var parseISO = require('date-fns/parseISO');
 
 function leapYear(year) {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
@@ -16,7 +17,7 @@ function isValidDate(inDate) {
       inDate = inDate.replace(/\./g, '-');
     }
     if (inDate.length === 10) {
-      return dateTools.isValid(dateTools.parseISO(inDate));
+      return isDateValid(parseISO(inDate));
     }
   }
 


### PR DESCRIPTION
**TLDR**: The bundle size has been reduced from almost 600K into 62K.

----

After clone:

```sh
14:32:58 ~/development/github/validatorjs {master}
$ npm run build > /dev/null && ll -h dist
total 604K
drwxrwxr-x 2 jacekk jacekk 4,0K Sep 19 14:33 lang
-rw-rw-r-- 1 jacekk jacekk 598K Sep 19 14:33 validator.js
```

Changed:

```sh
14:34:21 ~/development/github/validatorjs {bundle-size-optimization}
$ git diff
diff --git a/src/rules.js b/src/rules.js
index 0ed897a..ea86d8d 100755
--- a/src/rules.js
+++ b/src/rules.js
@@ -1,4 +1,5 @@
-var dateTools = require('date-fns');
+var isDateValid = require('date-fns/isValid');
+var parseISO = require('date-fns/parseISO');

 function leapYear(year) {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
@@ -16,7 +17,7 @@ function isValidDate(inDate) {
       inDate = inDate.replace(/\./g, '-');
     }
     if (inDate.length === 10) {
-      return dateTools.isValid(dateTools.parseISO(inDate));
+      return isDateValid(parseISO(inDate));
     }
   }
```

After changes:

```sh
14:34:27 ~/development/github/validatorjs {bundle-size-optimization} 
$ npm run build > /dev/null && ll -h dist
total 68K
drwxrwxr-x 2 jacekk jacekk 4,0K Sep 19 14:34 lang
-rw-rw-r-- 1 jacekk jacekk  62K Sep 19 14:34 validator.js
```