### PR TITLE
Add missing 'attributes' entry to language files

### DIFF
--- a/dist/lang/az.js
+++ b/dist/lang/az.js
@@ -8,6 +8,7 @@ module.exports = {
   alpha_dash: ':attribute yalnız hərf, rəqəm və tire simvolundan ibarət ola bilər',
   alpha_num: ':attribute yalnız hərf və rəqəmlərdən ibarət ola bilər',
   array: ':attribute massiv formatında olmalıdır',
+  attributes: {},
   before: ':attribute :date tarixindən əvvəl olmalıdır',
   before_or_equal: ':attribute :date tarixindən əvvəl və ya bərabər olmalıdır',
   between: {

--- a/dist/lang/be.js
+++ b/dist/lang/be.js
@@ -8,6 +8,7 @@ module.exports = {
   alpha_dash: 'Поле :attribute можа мець толькі літары, лічбы і злучок.',
   alpha_num: 'Поле :attribute можа мець толькі літары і лічбы.',
   array: 'Поле :attribute павінна быць масівам.',
+  attributes: {},
   before: 'У полі :attribute павінна быць дата да :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',
   between: {

--- a/dist/lang/bg.js
+++ b/dist/lang/bg.js
@@ -8,6 +8,7 @@ module.exports = {
   alpha_dash: 'Полето :attribute трябва да съдържа само букви, цифри, долна черта и тире.',
   alpha_num: 'Полето :attribute трябва да съдържа само букви и цифри.',
   array: 'Полето :attribute трябва да бъде масив.',
+  attributes: {},
   before: 'Полето :attribute трябва да бъде дата преди :date.',
   before_or_equal: 'Полето :attribute трябва да бъде дата преди или равна на :date.',
   between: {

--- a/dist/lang/pt_BR.js
+++ b/dist/lang/pt_BR.js
@@ -8,6 +8,7 @@ module.exports = {
   alpha_dash: 'O campo :attribute deve conter apenas letras, números e traços.',
   alpha_num: 'O campo :attribute deve conter apenas letras e números .',
   array: 'O campo :attribute deve conter um array.',
+  attributes: {},
   before: 'O campo :attribute deve conter uma data anterior a :date.',
   before_or_equal: 'O campo :attribute deve conter uma data inferior ou igual a :date.',
   between: {

--- a/dist/lang/sv.js
+++ b/dist/lang/sv.js
@@ -8,6 +8,7 @@ module.exports = {
   alpha_dash: ':attribute får endast innehålla bokstäver, siffror och bindestreck.',
   alpha_num: ':attribute får endast innehålla bokstäver och siffror.',
   array: ':attribute måste vara en array.',
+  attributes: {},
   before: ':attribute måste vara ett datum innan den :date.',
   before_or_equal: ':attribute måste vara ett datum före eller samma dag som :date.',
   between: {

--- a/src/lang/az.js
+++ b/src/lang/az.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute yalnız hərf, rəqəm və tire simvolundan ibarət ola bilər',
   alpha_num: ':attribute yalnız hərf və rəqəmlərdən ibarət ola bilər',
   array: ':attribute massiv formatında olmalıdır',
+  attributes: {},
   before: ':attribute :date tarixindən əvvəl olmalıdır',
   before_or_equal: ':attribute :date tarixindən əvvəl və ya bərabər olmalıdır',
   between: {

--- a/src/lang/be.js
+++ b/src/lang/be.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'Поле :attribute можа мець толькі літары, лічбы і злучок.',
   alpha_num: 'Поле :attribute можа мець толькі літары і лічбы.',
   array: 'Поле :attribute павінна быць масівам.',
+  attributes: {},
   before: 'У полі :attribute павінна быць дата да :date.',
   before_or_equal: 'The :attribute must be a date before or equal to :date.',
   between: {

--- a/src/lang/bg.js
+++ b/src/lang/bg.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'Полето :attribute трябва да съдържа само букви, цифри, долна черта и тире.',
   alpha_num: 'Полето :attribute трябва да съдържа само букви и цифри.',
   array: 'Полето :attribute трябва да бъде масив.',
+  attributes: {},
   before: 'Полето :attribute трябва да бъде дата преди :date.',
   before_or_equal: 'Полето :attribute трябва да бъде дата преди или равна на :date.',
   between: {

--- a/src/lang/pt_BR.js
+++ b/src/lang/pt_BR.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: 'O campo :attribute deve conter apenas letras, números e traços.',
   alpha_num: 'O campo :attribute deve conter apenas letras e números .',
   array: 'O campo :attribute deve conter um array.',
+  attributes: {},
   before: 'O campo :attribute deve conter uma data anterior a :date.',
   before_or_equal: 'O campo :attribute deve conter uma data inferior ou igual a :date.',
   between: {

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -7,6 +7,7 @@ module.exports = {
   alpha_dash: ':attribute får endast innehålla bokstäver, siffror och bindestreck.',
   alpha_num: ':attribute får endast innehålla bokstäver och siffror.',
   array: ':attribute måste vara en array.',
+  attributes: {},
   before: ':attribute måste vara ett datum innan den :date.',
   before_or_equal: ':attribute måste vara ett datum före eller samma dag som :date.',
   between: {


### PR DESCRIPTION
PR #329 forgot some language files.

"There are some lang files missing the attributes key in the master branch:
`be.js, bg.js, pt_BR.js and sv.js`."

_Originally posted by @charlesrochati in https://github.com/skaterdav85/validatorjs/pull/329#issuecomment-567959429_