### PR TITLE
Fix Validator._replaceWildCards

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -296,7 +296,7 @@ Validator.prototype = {
       if(Array.isArray(path2)){
         path2 = path2[0];
       }
-      pos = path2.indexOf('*');
+      const pos = path2.indexOf('*');
       if (pos === -1) {
         return path2;
       }


### PR DESCRIPTION
When using wildcard validation rules with strict mode enabled, the following error is produced in the browser:

![Screenshot 2020-03-19 at 15 28 58](https://user-images.githubusercontent.com/60427623/77084409-d682f780-69f6-11ea-9fa3-4f5078604cfb.png)

This is resolved by explicitly declaring the `pos` variable in the [relevant function](https://github.com/skaterdav85/validatorjs/blob/master/src/validator.js#L299).