### PR TITLE
Ip validation

### DIFF
--- a/spec/ip.js
+++ b/spec/ip.js
@@ -7,7 +7,88 @@ if (typeof require !== 'undefined') {
 }
 
 describe('IP Validation rules', function () {
+
   describe('IPv4 Validation rule', function () {
+    it('should accept localhost ipv4 addres', function () {
+      var validator = new Validator({
+        ipAddr: '127.0.0.1'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should accept maximum ip range ', function () {
+      var validator = new Validator({
+        ipAddr: '255.255.255.255'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should accept random ip address withing range ', function () {
+      var validator = new Validator({
+        ipAddr: '192.168.33.10'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should fail ip address containing non integer octants', function () {
+      var validator = new Validator({
+        ipAddr: '192.fail.33.10'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
+
+    it('should fail ip address containing non integer octants', function () {
+      var validator = new Validator({
+        ipAddr: '192.fail.33.10'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
+
+    it('should fail ip address more than 4 octants', function () {
+      var validator = new Validator({
+        ipAddr: '192.168.33.10.10'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
+
+    it('should fail ip address less than 4 octants', function () {
+      var validator = new Validator({
+        ipAddr: '192.168.10'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
+
+    it('should fail ip address which contains octant values more than 255', function () {
+      var validator = new Validator({
+        ipAddr: '256.168.10.0'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
+
+    it('should fail ip address which contains empty octants', function () {
+      var validator = new Validator({
+        ipAddr: '256...0'
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.fail;
+    });
   });
 
   describe('IPv6 Validation rule', function () {

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -1,0 +1,15 @@
+if (typeof require !== 'undefined') {
+  var Validator = require('../src/validator.js');
+  var expect = require('chai').expect;
+} else {
+  var Validator = window.Validator;
+  var expect = window.chai.expect;
+}
+
+describe('IP Validation rules', function () {
+  describe('IPv4 Validation rule', function () {
+  });
+
+  describe('IPv6 Validation rule', function () {
+  });
+});

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -42,7 +42,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
 
     it('should fail ip address containing non integer octants', function () {
@@ -51,7 +51,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
 
     it('should fail ip address more than 4 octants', function () {
@@ -60,7 +60,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
 
     it('should fail ip address less than 4 octants', function () {
@@ -69,7 +69,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
 
     it('should fail ip address which contains octant values more than 255', function () {
@@ -78,7 +78,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
 
     it('should fail ip address which contains empty octants', function () {
@@ -87,7 +87,7 @@ describe('IP Validation rules', function () {
       }, {
         ipAddr: 'ipv4'
       });
-      expect(validator.passes()).to.be.fail;
+      expect(validator.passes()).to.be.false;
     });
   });
 

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -92,5 +92,103 @@ describe('IP Validation rules', function () {
   });
 
   describe('IPv6 Validation rule', function () {
+    it('should pass normal ipv6 address ', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should pass normal ipv6 address with ommited zeros', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:0:0:8a2e:0370:7334'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should pass max ipv6 address', function () {
+      var validator = new Validator({
+        ipAddr: 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should pass ipv6 address with ommiting section of zeros', function () {
+      var validator = new Validator({
+        ipAddr: '2001:db8::ff00:42:8329'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should pass ipv6 address of localhost', function () {
+      var validator = new Validator({
+        ipAddr: '::1'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should fail on ipv4 address', function () {
+      var validator = new Validator({
+        ipAddr: '192.168.33.10'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv4 address', function () {
+      var validator = new Validator({
+        ipAddr: '192.168.33.10'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv6 address with more than 8 sectors', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:1234:5349:8a2e:0370:7334:1234'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv6 address with less than 2 sectors', function () {
+      var validator = new Validator({
+        ipAddr: ':2000'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv6 address with bigger values in octet than ffff', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:1234:123456789:8a2e:0370:7334:'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv6 address when consecutive ommiting sections occure', function () {
+      var validator = new Validator({
+        ipAddr: '234::123::23'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
   });
 });

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -9,7 +9,7 @@ if (typeof require !== 'undefined') {
 describe('IP Validation rules', function () {
 
   describe('IPv4 Validation rule', function () {
-    it('should accept localhost ipv4 addres', function () {
+    it('should pass localhost ipv4 addres', function () {
       var validator = new Validator({
         ipAddr: '127.0.0.1'
       }, {
@@ -18,7 +18,7 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
-    it('should accept maximum ip range ', function () {
+    it('should pass maximum ip range ', function () {
       var validator = new Validator({
         ipAddr: '255.255.255.255'
       }, {
@@ -27,7 +27,7 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
-    it('should accept random ip address withing range ', function () {
+    it('should pass random ip address withing range ', function () {
       var validator = new Validator({
         ipAddr: '192.168.33.10'
       }, {
@@ -247,7 +247,7 @@ describe('IP Validation rules', function () {
   });
 
   describe('IP General Validation rule', function () {
-    it('should accept localhost ipv4 addres', function () {
+    it('should pass localhost ipv4 addres', function () {
       var validator = new Validator({
         ipAddr: '127.0.0.1'
       }, {
@@ -256,7 +256,7 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
-    it('should accept minimum ipv4 addres', function () {
+    it('should pass minimum ipv4 addres', function () {
       var validator = new Validator({
         ipAddr: '0.0.0.0'
       }, {
@@ -265,7 +265,7 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
-    it('should accept localhost ipv6 addres', function () {
+    it('should pass localhost ipv6 addres', function () {
       var validator = new Validator({
         ipAddr: '::1'
       }, {
@@ -274,7 +274,7 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
-    it('should accept normal ipv6 addres', function () {
+    it('should pass normal ipv6 addres', function () {
       var validator = new Validator({
         ipAddr: '2001:0db8:85a3:0:0:8a2e:0370:7334'
       }, {

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -146,15 +146,6 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.false;
     });
 
-    it('should fail on ipv4 address', function () {
-      var validator = new Validator({
-        ipAddr: '192.168.33.10'
-      }, {
-        ipAddr: 'ipv6'
-      });
-      expect(validator.passes()).to.be.false;
-    });
-
     it('should fail on ipv6 address with more than 8 sectors', function () {
       var validator = new Validator({
         ipAddr: '2001:0db8:85a3:1234:5349:8a2e:0370:7334:1234'
@@ -175,7 +166,7 @@ describe('IP Validation rules', function () {
 
     it('should fail on ipv6 address with bigger values in octet than ffff', function () {
       var validator = new Validator({
-        ipAddr: '2001:0db8:85a3:1234:123456789:8a2e:0370:7334:'
+        ipAddr: '2001:0db8:85a3:1234:123456789:8a2e:0370:7334'
       }, {
         ipAddr: 'ipv6'
       });

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -146,6 +146,24 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.true;
     });
 
+    it('should pass ipv6 input with 7 hextets and ending omitting sector', function () {
+      var validator = new Validator({
+        ipAddr: '1:2:3:4:5:6:7::'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should pass ipv6 input with 7 hextets and leading omitting sector', function () {
+      var validator = new Validator({
+        ipAddr: '::2:3:4:5:6:7:8'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
     it('should fail on ipv4 address', function () {
       var validator = new Validator({
         ipAddr: '192.168.33.10'
@@ -194,6 +212,33 @@ describe('IP Validation rules', function () {
     it('should fail on non string input', function () {
       var validator = new Validator({
         ipAddr: 1234
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on ipv6 input with less then 8 hextets and no omitting sector', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:9876:1234:8a2e'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail ipv6 input with 8 hextets and one omitting sector', function () {
+      var validator = new Validator({
+        ipAddr: '1:2:3:4:5::6:7:8'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail ipv6 starting with one colon', function () {
+      var validator = new Validator({
+        ipAddr: ':1:2:3:4:5:6:7'
       }, {
         ipAddr: 'ipv6'
       });

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -89,6 +89,15 @@ describe('IP Validation rules', function () {
       });
       expect(validator.passes()).to.be.false;
     });
+
+    it('should fail on non string input', function () {
+      var validator = new Validator({
+        ipAddr: 1234
+      }, {
+        ipAddr: 'ipv4'
+      });
+      expect(validator.passes()).to.be.false;
+    });
   });
 
   describe('IPv6 Validation rule', function () {
@@ -176,6 +185,15 @@ describe('IP Validation rules', function () {
     it('should fail on ipv6 address when consecutive ommiting sections occure', function () {
       var validator = new Validator({
         ipAddr: '234::123::23'
+      }, {
+        ipAddr: 'ipv6'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on non string input', function () {
+      var validator = new Validator({
+        ipAddr: 1234
       }, {
         ipAddr: 'ipv6'
       });

--- a/spec/ip.js
+++ b/spec/ip.js
@@ -245,4 +245,60 @@ describe('IP Validation rules', function () {
       expect(validator.passes()).to.be.false;
     });
   });
+
+  describe('IP General Validation rule', function () {
+    it('should accept localhost ipv4 addres', function () {
+      var validator = new Validator({
+        ipAddr: '127.0.0.1'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should accept minimum ipv4 addres', function () {
+      var validator = new Validator({
+        ipAddr: '0.0.0.0'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should accept localhost ipv6 addres', function () {
+      var validator = new Validator({
+        ipAddr: '::1'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should accept normal ipv6 addres', function () {
+      var validator = new Validator({
+        ipAddr: '2001:0db8:85a3:0:0:8a2e:0370:7334'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.true;
+    });
+
+    it('should fail on random string ipv4 type', function () {
+      var validator = new Validator({
+        ipAddr: 'F.A.I.L'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+
+    it('should fail on random string ipv6 type', function () {
+      var validator = new Validator({
+        ipAddr: 'F:A:I:L:U:R:E:!:'
+      }, {
+        ipAddr: 'ip'
+      });
+      expect(validator.passes()).to.be.false;
+    });
+  });
 });

--- a/src/rules.js
+++ b/src/rules.js
@@ -451,6 +451,9 @@ var rules = {
 
     // if all checks passed, we know it's valid IPv4 address!
     return true;
+  },
+
+  ipv6: function (val, req, attribute) {
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -429,6 +429,28 @@ var rules = {
   },
 
   ipv4: function (val, req, attribute) {
+    // regex to check that each octet is valid
+    var er = /^[0-9]+$/;
+    // ipv4 octets are delimited by dot 
+    octets = val.split('.');
+    // check 1: ipv4 address should contains 4 octets
+    if (octets.length != 4)
+      return false;
+
+    for (let i = 0; i < octets.length; i++) {
+      const element = octets[i];
+      // check 2: each octet should be integer bigger than 0
+      if (!er.test(element))
+        return false;
+
+      // check 3: each octet value should be less than 256
+      var octetValue = parseInt(element);
+      if (octetValue >= 256)
+        return false;
+    }
+
+    // if all checks passed, we know it's valid IPv4 address!
+    return true;
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -426,6 +426,9 @@ var rules = {
 
   hex: function(val) {
     return /^[0-9a-f]+$/i.test(val);
+  },
+
+  ipv4: function (val, req, attribute) {
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -510,6 +510,10 @@ var rules = {
         return false;
     }
     return true;
+  },
+  
+  ip: function (val, req, attribute) {
+    return rules['ipv4'](val,req,attribute) || rules['ipv6'](val,req,attribute);
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -454,6 +454,38 @@ var rules = {
   },
 
   ipv6: function (val, req, attribute) {
+    // regex to check that each hextet is valid
+    var er = /^[0-9a-f]+$/;
+    // ipv6 hextets are delimited by colon
+    hextets = val.split(':');
+
+    // check 1: ipv6 should contain no more than 8 sectors and no less than 3 sector
+    //         minimum ipv6 addres - ::1
+    if(3 > hextets.length  || hextets.length > 8)
+      return false;
+
+    // check 2: ipv6 should contain only one consecutive colons
+    consColonOccurances = val.match(/::/g);
+    if(consColonOccurances != null && consColonOccurances.length > 1)
+      return false;
+
+    for (let i = 0; i < hextets.length; i++) {
+      const element = hextets[i];
+      
+      if(element.length == 0)
+        continue;
+
+      // check 3: all of hextets should contain numbers from 0 to f (in hexadecimal)
+      if (!er.test(element))
+        return false;
+
+      // check 4: all of hextet values should be less then ffff (in hexadeimal)
+      //          checking using length of hextet. lowest invalid value's length is 5. 
+      //          so all valid hextets are length of 4 or less
+      if (element.length > 4)
+        return false;
+    }
+    return true;
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -465,14 +465,32 @@ var rules = {
     // ipv6 hextets are delimited by colon
     hextets = val.split(':');
 
-    // check 1: ipv6 should contain no more than 8 sectors and no less than 3 sector
-    //         minimum ipv6 addres - ::1
-    if(3 > hextets.length  || hextets.length > 8)
+    // check 1: ipv6 should contain only one consecutive colons
+    colons = val.match(/::/);
+    if(colons != null && val.match(/::/g).length > 1)
       return false;
 
-    // check 2: ipv6 should contain only one consecutive colons
-    consColonOccurances = val.match(/::/g);
-    if(consColonOccurances != null && consColonOccurances.length > 1)
+    // check 2: ipv6 should not be ending or starting with colon
+    //          edge case: not with consecutive colons
+    if(val[0] == ':' && (colons == null || (colons != null && colons.index != 0)))
+      return false;
+    if(val[val.length-1] == ':' && (colons == null || (colons != null && colons.index != val.length-2)))
+      return false;
+      
+    // check 3: ipv6 should contain no less than 3 sector
+    //         minimum ipv6 addres - ::1
+    if(3 > hextets.length)
+      return false;
+
+    // console.log()
+    // check 4: ipv6 should contain no more than 8 sectors
+    //         only 1 edge case: when first or last sector is ommited
+    var isEdgeCase = (hextets.length == 9 && colons != null && (colons.index == 0 || colons.index == val.length-2));
+    if(hextets.length > 8 && !isEdgeCase)
+      return false;
+
+    // check 5: ipv6 should contain exactly one consecutive colons if it has less than 8 sectors
+    if (hextets.length != 8 && colons == null)
       return false;
 
     for (let i = 0; i < hextets.length; i++) {
@@ -481,11 +499,11 @@ var rules = {
       if(element.length == 0)
         continue;
 
-      // check 3: all of hextets should contain numbers from 0 to f (in hexadecimal)
+      // check 6: all of hextets should contain numbers from 0 to f (in hexadecimal)
       if (!er.test(element))
         return false;
 
-      // check 4: all of hextet values should be less then ffff (in hexadeimal)
+      // check 7: all of hextet values should be less then ffff (in hexadeimal)
       //          checking using length of hextet. lowest invalid value's length is 5. 
       //          so all valid hextets are length of 4 or less
       if (element.length > 4)

--- a/src/rules.js
+++ b/src/rules.js
@@ -429,9 +429,9 @@ var rules = {
   },
 
   ipv4: function (val, req, attribute) {
-    if(typeof val != 'string')
+    if (typeof val != 'string')
       return false;
-      
+
     // regex to check that each octet is valid
     var er = /^[0-9]+$/;
     // ipv4 octets are delimited by dot 
@@ -457,7 +457,7 @@ var rules = {
   },
 
   ipv6: function (val, req, attribute) {
-    if(typeof val != 'string')
+    if (typeof val != 'string')
       return false;
 
     // regex to check that each hextet is valid
@@ -467,26 +467,25 @@ var rules = {
 
     // check 1: ipv6 should contain only one consecutive colons
     colons = val.match(/::/);
-    if(colons != null && val.match(/::/g).length > 1)
+    if (colons != null && val.match(/::/g).length > 1)
       return false;
 
     // check 2: ipv6 should not be ending or starting with colon
     //          edge case: not with consecutive colons
-    if(val[0] == ':' && (colons == null || (colons != null && colons.index != 0)))
+    if (val[0] == ':' && (colons == null || (colons != null && colons.index != 0)))
       return false;
-    if(val[val.length-1] == ':' && (colons == null || (colons != null && colons.index != val.length-2)))
-      return false;
-      
-    // check 3: ipv6 should contain no less than 3 sector
-    //         minimum ipv6 addres - ::1
-    if(3 > hextets.length)
+    if (val[val.length - 1] == ':' && (colons == null || (colons != null && colons.index != val.length - 2)))
       return false;
 
-    // console.log()
+    // check 3: ipv6 should contain no less than 3 sector
+    //         minimum ipv6 addres - ::1
+    if (3 > hextets.length)
+      return false;
+
     // check 4: ipv6 should contain no more than 8 sectors
     //         only 1 edge case: when first or last sector is ommited
-    var isEdgeCase = (hextets.length == 9 && colons != null && (colons.index == 0 || colons.index == val.length-2));
-    if(hextets.length > 8 && !isEdgeCase)
+    var isEdgeCase = (hextets.length == 9 && colons != null && (colons.index == 0 || colons.index == val.length - 2));
+    if (hextets.length > 8 && !isEdgeCase)
       return false;
 
     // check 5: ipv6 should contain exactly one consecutive colons if it has less than 8 sectors
@@ -495,8 +494,8 @@ var rules = {
 
     for (let i = 0; i < hextets.length; i++) {
       const element = hextets[i];
-      
-      if(element.length == 0)
+
+      if (element.length == 0)
         continue;
 
       // check 6: all of hextets should contain numbers from 0 to f (in hexadecimal)
@@ -511,9 +510,9 @@ var rules = {
     }
     return true;
   },
-  
+
   ip: function (val, req, attribute) {
-    return rules['ipv4'](val,req,attribute) || rules['ipv6'](val,req,attribute);
+    return rules['ipv4'](val, req, attribute) || rules['ipv6'](val, req, attribute);
   }
 };
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -429,6 +429,9 @@ var rules = {
   },
 
   ipv4: function (val, req, attribute) {
+    if(typeof val != 'string')
+      return false;
+      
     // regex to check that each octet is valid
     var er = /^[0-9]+$/;
     // ipv4 octets are delimited by dot 
@@ -454,6 +457,9 @@ var rules = {
   },
 
   ipv6: function (val, req, attribute) {
+    if(typeof val != 'string')
+      return false;
+
     // regex to check that each hextet is valid
     var er = /^[0-9a-f]+$/;
     // ipv6 hextets are delimited by colon


### PR DESCRIPTION
Following patch implements validation of IPv4 and IPv6, mentioned in following issue #365.

source code Implemented 3 rules:
'ipv4' - validates IPv4
'ipv6' - validates IPv6
'ip' - validates both

tests are written in ip.js.