### PR TITLE
Adding 'attribute' property on pt_BR lang file

### DIFF
--- a/src/lang/pt_BR.js
+++ b/src/lang/pt_BR.js
@@ -97,5 +97,6 @@ module.exports = {
   timezone: 'O campo :attribute deve conter um fuso horário válido.',
   unique: 'O valor informado para o campo :attribute já está em uso.',
   uploaded: 'Falha no Upload do arquivo :attribute.',
-  url: 'O formato da URL informada para o campo :attribute é inválido.'
+  url: 'O formato da URL informada para o campo :attribute é inválido.',
+  attributes: {}
 };


### PR DESCRIPTION
Added missing property (compared to the others lang files) to make validation functional

As described in issue [Property 'attributes' missing on pt_BR lang](https://github.com/skaterdav85/validatorjs/issues/370)