### PR TITLE
Add custom replacement to custom rules

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -45,7 +45,6 @@ var container = {
    * @param {function} fn 
    */
   _setCustomReplement: function(name, fn) {
-    console.log('opa!');
     if (fn !== undefined) {
       this.attributes[name] = function(template, rule) {
         const replacement = fn(template, rule, this._getAttributeName);

--- a/src/lang.js
+++ b/src/lang.js
@@ -48,7 +48,9 @@ var container = {
     if (fn !== undefined) {
       this.attributes[name] = function(template, rule) {
         const replacement = fn(template, rule, this._getAttributeName);
-        return this._replacePlaceholders(rule, template, replacement);
+        return 'object' === typeof replacement
+          ? this._replacePlaceholders(rule, template, replacement)
+          : replacement;
       };
     }
   },

--- a/src/lang.js
+++ b/src/lang.js
@@ -6,8 +6,6 @@ var require_method = require;
 
 var container = {
 
-  attributes: {},
-
   messages: {},
 
   /**
@@ -36,22 +34,6 @@ var container = {
     }
 
     this.messages[lang][attribute] = message;
-  },
-
-  /**
-   * Set a custom replacement to message
-   * 
-   * @param {string} name 
-   * @param {function} fn 
-   */
-  _setCustomReplement: function(name, fn) {
-    console.log('opa!');
-    if (fn !== undefined) {
-      this.attributes[name] = function(template, rule) {
-        const replacement = fn(template, rule, this._getAttributeName);
-        return this._replacePlaceholders(rule, template, replacement);
-      };
-    }
   },
 
   /**
@@ -88,7 +70,7 @@ var container = {
    */
   _make: function(lang) {
     this._load(lang);
-    return new Messages(lang, this.messages[lang], this.attributes);
+    return new Messages(lang, this.messages[lang]);
   }
 
 };

--- a/src/lang.js
+++ b/src/lang.js
@@ -6,6 +6,8 @@ var require_method = require;
 
 var container = {
 
+  attributes: {},
+
   messages: {},
 
   /**
@@ -34,6 +36,22 @@ var container = {
     }
 
     this.messages[lang][attribute] = message;
+  },
+
+  /**
+   * Set a custom replacement to message
+   * 
+   * @param {string} name 
+   * @param {function} fn 
+   */
+  _setCustomReplement: function(name, fn) {
+    console.log('opa!');
+    if (fn !== undefined) {
+      this.attributes[name] = function(template, rule) {
+        const replacement = fn(template, rule, this._getAttributeName);
+        return this._replacePlaceholders(rule, template, replacement);
+      };
+    }
   },
 
   /**
@@ -70,7 +88,7 @@ var container = {
    */
   _make: function(lang) {
     this._load(lang);
-    return new Messages(lang, this.messages[lang]);
+    return new Messages(lang, this.messages[lang], this.attributes);
   }
 
 };

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,10 +1,11 @@
 var Attributes = require('./attributes');
 
-var Messages = function(lang, messages) {
+var Messages = function(lang, messages, customReplacements) {
   this.lang = lang;
   this.messages = messages;
   this.customMessages = {};
   this.attributeNames = {};
+  Attributes.replacements = { ...Attributes.replacements, ...customReplacements };
 };
 
 Messages.prototype = {

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,11 +1,10 @@
 var Attributes = require('./attributes');
 
-var Messages = function(lang, messages, customReplacements) {
+var Messages = function(lang, messages) {
   this.lang = lang;
   this.messages = messages;
   this.customMessages = {};
   this.attributeNames = {};
-  Attributes.replacements = { ...Attributes.replacements, ...customReplacements };
 };
 
 Messages.prototype = {

--- a/src/validator.js
+++ b/src/validator.js
@@ -593,12 +593,14 @@ Validator.stopOnError = function (attributes) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.register = function (name, fn, message) {
+Validator.register = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.register(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -607,12 +609,14 @@ Validator.register = function (name, fn, message) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerImplicit = function (name, fn, message) {
+Validator.registerImplicit = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerImplicit(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -623,10 +627,11 @@ Validator.registerImplicit = function (name, fn, message) {
  * @param  {string}   message
  * @return {void}
  */
-Validator.registerAsync = function (name, fn, message) {
+Validator.registerAsync = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerAsync(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**

--- a/src/validator.js
+++ b/src/validator.js
@@ -296,6 +296,7 @@ Validator.prototype = {
       if(Array.isArray(path2)){
         path2 = path2[0];
       }
+      const pos = path2.indexOf('*');
       if (pos === -1) {
         return path2;
       }
@@ -592,14 +593,12 @@ Validator.stopOnError = function (attributes) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
- * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.register = function (name, fn, message, fnReplacement) {
+Validator.register = function (name, fn, message) {
   var lang = Validator.getDefaultLang();
   Rules.register(name, fn);
   Lang._setRuleMessage(lang, name, message);
-  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -608,14 +607,12 @@ Validator.register = function (name, fn, message, fnReplacement) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
- * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerImplicit = function (name, fn, message, fnReplacement) {
+Validator.registerImplicit = function (name, fn, message) {
   var lang = Validator.getDefaultLang();
   Rules.registerImplicit(name, fn);
   Lang._setRuleMessage(lang, name, message);
-  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -626,11 +623,10 @@ Validator.registerImplicit = function (name, fn, message, fnReplacement) {
  * @param  {string}   message
  * @return {void}
  */
-Validator.registerAsync = function (name, fn, message, fnReplacement) {
+Validator.registerAsync = function (name, fn, message) {
   var lang = Validator.getDefaultLang();
   Rules.registerAsync(name, fn);
   Lang._setRuleMessage(lang, name, message);
-  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**

--- a/src/validator.js
+++ b/src/validator.js
@@ -296,7 +296,6 @@ Validator.prototype = {
       if(Array.isArray(path2)){
         path2 = path2[0];
       }
-      const pos = path2.indexOf('*');
       if (pos === -1) {
         return path2;
       }
@@ -593,12 +592,14 @@ Validator.stopOnError = function (attributes) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.register = function (name, fn, message) {
+Validator.register = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.register(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -607,12 +608,14 @@ Validator.register = function (name, fn, message) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerImplicit = function (name, fn, message) {
+Validator.registerImplicit = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerImplicit(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**
@@ -623,10 +626,11 @@ Validator.registerImplicit = function (name, fn, message) {
  * @param  {string}   message
  * @return {void}
  */
-Validator.registerAsync = function (name, fn, message) {
+Validator.registerAsync = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerAsync(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Lang._setCustomReplement(name, fnReplacement);
 };
 
 /**


### PR DESCRIPTION
This will allow custom rules to add custom overrides/replacements, such as:
```
  Validator.register(
    'date_between',
    function (value, requirement) {
      // custom validation using dates
    },
    'Custom message for attribute :attribute with replacements :min and :max.',
    function (_template, rule, _getAttributeName) {
      const parameters = rule.getParameters();
        return {
          min: parameters[0],
          max: parameters[1],
        };
    }
  )
```
Edit 1:
This will meet this requirement/issue( #136 )