### PR TITLE
Changed message according to type

### DIFF
--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -7,7 +7,10 @@ module.exports = {
   alpha_num: 'The :attribute field must be alphanumeric.',
   before: 'The :attribute must be before :before.',
   before_or_equal: 'The :attribute must be equal or before :before_or_equal.',
-  between: 'The :attribute field must be between :min and :max.',
+  between: {
+    numeric: 'The :attribute must be between :min and :max.',
+    string: 'The :attribute must be between :min and :max characters.',
+  },
   confirmed: 'The :attribute confirmation does not match.',
   email: 'The :attribute format is invalid.',
   date: 'The :attribute is not a valid date format.',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -7,7 +7,10 @@ module.exports = {
   alpha_num: ':attributeは英数字のみで入力してください。',
   before: ':attributeは:beforeより前の日付を入力してください。',
   before_or_equal: ':attributeは:before_or_equal以前の日付を入力してください。',
-  between: ':attributeは:min〜:max文字で入力してください。',
+  between: {
+    numeric: ':attributeは:min〜:maxの間で指定してください',
+    string: ':attributeは:min〜:max文字を入力してください',
+  },
   confirmed: ':attributeは確認が一致しません。',
   email: ':attributeは正しいメールアドレスを入力してください。',
   date: ':attributeは正しい日付形式を入力してください',


### PR DESCRIPTION
Strengthened the message in the Between rule.

Even without reinforcement, the message seems to make sense in English,
but in Japanese, the context was not correct and it was an obvious display problem.

This time I have corrected the English and Japanese languages. We hope that volunteers will promote other languages as well.