### PR TITLE
add [Register Custom Validation Replacement Function]

### DIFF
--- a/src/attributes.js
+++ b/src/attributes.js
@@ -193,7 +193,12 @@ function formatter(attribute) {
   return attribute.replace(/[_\[]/g, ' ').replace(/]/g, '');
 }
 
+function register(name, fn) {
+  replacements[name] = fn;
+}
+
 module.exports = {
   replacements: replacements,
-  formatter: formatter
+  formatter: formatter,
+  register: register
 };

--- a/src/rules.js
+++ b/src/rules.js
@@ -171,8 +171,8 @@ var rules = {
   between: function(val, req, attribute) {
     req = this.getParameters();
     var size = this.getSize();
-    var min = parseFloat(req[0], 10);
-    var max = parseFloat(req[1], 10);
+    var min = parseFloat(req[0]);
+    var max = parseFloat(req[1]);
     return size >= min && size <= max;
   },
 
@@ -325,8 +325,8 @@ var rules = {
     var numericRule = this.validator.getRule('numeric');
     var req = this.getParameters();
     var valueDigitsCount = String(val).length;
-    var min = parseFloat(req[0], 10);
-    var max = parseFloat(req[1], 10);
+    var min = parseFloat(req[0]);
+    var max = parseFloat(req[1]);
 
     if (numericRule.validate(val) && valueDigitsCount >= min && valueDigitsCount <= max) {
       return true;
@@ -525,10 +525,11 @@ Rule.prototype = {
   /**
    * Get true size of value
    *
+   * @param {mixed} val // How to ensure this.inputValue has .length
    * @return {integer|float}
    */
-  getSize: function() {
-    var value = this.inputValue;
+  getSize: function(val) {
+    var value = val || this.inputValue;
 
     if (value instanceof Array) {
       return value.length;
@@ -539,7 +540,7 @@ Rule.prototype = {
     }
 
     if (this.validator._hasNumericRule(this.attribute)) {
-      return parseFloat(value, 10);
+      return parseFloat(value);
     }
 
     return value.length;

--- a/src/validator.js
+++ b/src/validator.js
@@ -593,12 +593,14 @@ Validator.stopOnError = function (attributes) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.register = function (name, fn, message) {
+Validator.register = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.register(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Attributes.register(name, fnReplacement);
 };
 
 /**
@@ -607,12 +609,14 @@ Validator.register = function (name, fn, message) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerImplicit = function (name, fn, message) {
+Validator.registerImplicit = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerImplicit(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Attributes.register(name, fnReplacement);
 };
 
 /**
@@ -621,12 +625,14 @@ Validator.registerImplicit = function (name, fn, message) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerAsync = function (name, fn, message) {
+Validator.registerAsync = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerAsync(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Attributes.register(name, fnReplacement);
 };
 
 /**
@@ -635,12 +641,14 @@ Validator.registerAsync = function (name, fn, message) {
  * @param  {string}   name
  * @param  {function} fn
  * @param  {string}   message
+ * @param  {function} fnReplacement
  * @return {void}
  */
-Validator.registerAsyncImplicit = function (name, fn, message) {
+Validator.registerAsyncImplicit = function (name, fn, message, fnReplacement) {
   var lang = Validator.getDefaultLang();
   Rules.registerAsyncImplicit(name, fn);
   Lang._setRuleMessage(lang, name, message);
+  Attributes.register(name, fnReplacement);
 };
 
 /**


### PR DESCRIPTION
It's amazing!

The package i installed via npm, `@param  {function} fnReplacement` are reserved  in the args of validator.js‘s `register, registerImplicit, registerAsync, registerAsyncImplicit function`

but, This param is not in the src that i cloned.

Sometimes a custom replacement function is required when `Register Custom Validation Rules`

-----------------------------------------------------------------------------------------------

很神奇的一件事

我通过npm安装的包，这四个方法都有预留 fnReplacement 参数，只是没用而已

但是在我克隆的代码里，这个参数却没了

有时候，注册一个验证规则时，必须要自定义一个替换消息占位符的方法